### PR TITLE
feat: scaffold action validation pipeline

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,9 @@ executor = true
 events = true
 rules = true
 llm_visible = true
+action_validation = false
+predicate_gate = false
+mcp = false
 
 # Retrieval-augmented orchestration.
 # Note: provider "none" uses the built-in SQL fallback retriever.

--- a/src/Adventorator/action_validation/__init__.py
+++ b/src/Adventorator/action_validation/__init__.py
@@ -1,0 +1,29 @@
+"""Action validation public exports."""
+
+from .schemas import (
+    AskReport,
+    ExecutionRequest,
+    ExecutionResult,
+    IntentFrame,
+    Plan,
+    PlanStep,
+    execution_request_from_tool_chain,
+    plan_from_planner_output,
+    planner_output_from_plan,
+    tool_chain_from_execution_request,
+)
+from . import registry as plan_registry
+
+__all__ = [
+    "AskReport",
+    "plan_registry",
+    "ExecutionRequest",
+    "ExecutionResult",
+    "IntentFrame",
+    "Plan",
+    "PlanStep",
+    "execution_request_from_tool_chain",
+    "plan_from_planner_output",
+    "planner_output_from_plan",
+    "tool_chain_from_execution_request",
+]

--- a/src/Adventorator/action_validation/registry.py
+++ b/src/Adventorator/action_validation/registry.py
@@ -1,0 +1,21 @@
+"""Simple in-memory registry for transient Plans during the rollout."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .schemas import Plan
+
+_PLANS: Dict[str, Plan] = {}
+
+
+def register_plan(plan: Plan) -> None:
+    _PLANS[plan.plan_id] = plan
+
+
+def get_plan(plan_id: str) -> Plan | None:
+    return _PLANS.get(plan_id)
+
+
+def reset() -> None:
+    _PLANS.clear()

--- a/src/Adventorator/action_validation/schemas.py
+++ b/src/Adventorator/action_validation/schemas.py
@@ -1,0 +1,147 @@
+"""Pydantic models and interop helpers for the action validation pipeline."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Iterable
+
+from pydantic import BaseModel, Field
+
+from Adventorator.executor import ToolCallChain, ToolStep
+from Adventorator.planner_schemas import PlannerOutput
+
+
+class IntentFrame(BaseModel):
+    action: str
+    actor: str
+    object_ref: str | None = None
+    target_ref: str | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+    tags: set[str] = Field(default_factory=set)
+    guidance: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = dict(extra="forbid", frozen=True)
+
+
+class AskReport(BaseModel):
+    intent: IntentFrame
+    candidates: list[IntentFrame] = Field(default_factory=list)
+    policy_flags: dict[str, Any] = Field(default_factory=dict)
+    rationale: str = ""
+
+    model_config = dict(extra="forbid", frozen=True)
+
+
+class PlanStep(BaseModel):
+    op: str
+    args: dict[str, Any] = Field(default_factory=dict)
+    guards: list[str] = Field(default_factory=list)
+
+    model_config = dict(extra="forbid", frozen=True)
+
+
+class Plan(BaseModel):
+    feasible: bool
+    plan_id: str
+    steps: list[PlanStep] = Field(default_factory=list)
+    failed_predicates: list[dict[str, Any]] = Field(default_factory=list)
+    repairs: list[str] = Field(default_factory=list)
+    alternatives: list[IntentFrame] = Field(default_factory=list)
+    rationale: str = ""
+
+    model_config = dict(extra="forbid", frozen=True)
+
+
+class ExecutionRequest(BaseModel):
+    plan_id: str
+    steps: list[PlanStep]
+    context: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = dict(extra="forbid", frozen=True)
+
+
+class ExecutionResult(BaseModel):
+    ok: bool
+    events: list[dict[str, Any]] = Field(default_factory=list)
+    state_delta: dict[str, Any] = Field(default_factory=dict)
+    narration_cues: list[str] = Field(default_factory=list)
+
+    model_config = dict(extra="forbid", frozen=True)
+
+
+# -----------------
+# Conversion helpers
+# -----------------
+
+
+def _normalize_command_name(command: str, subcommand: str | None) -> str:
+    base = command.strip()
+    if subcommand:
+        return f"{base}.{subcommand.strip()}"
+    return base
+
+
+def _split_command_name(op: str) -> tuple[str, str | None]:
+    if "." in op:
+        top, _, sub = op.partition(".")
+        top = top.strip()
+        sub = sub.strip() or None
+        return top, sub
+    return op.strip(), None
+
+
+def _stable_plan_id(seed: Iterable[tuple[str, Any]]) -> str:
+    payload = json.dumps(sorted((k, v) for k, v in seed), sort_keys=True).encode()
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def plan_from_planner_output(out: PlannerOutput, *, plan_id: str | None = None) -> Plan:
+    op = _normalize_command_name(out.command, out.subcommand)
+    step = PlanStep(op=op, args=dict(out.args))
+    if plan_id is None:
+        plan_id = _stable_plan_id(
+            (
+                ("command", out.command),
+                ("subcommand", out.subcommand),
+                ("args", out.args),
+            )
+        )
+    return Plan(feasible=True, plan_id=plan_id, steps=[step])
+
+
+def planner_output_from_plan(plan: Plan) -> PlannerOutput:
+    if not plan.steps:
+        raise ValueError("Plan has no steps to convert")
+    first = plan.steps[0]
+    command, subcommand = _split_command_name(first.op)
+    return PlannerOutput(command=command, subcommand=subcommand, args=dict(first.args))
+
+
+def execution_request_from_tool_chain(chain: ToolCallChain, *, plan_id: str) -> ExecutionRequest:
+    steps = [
+        PlanStep(
+            op=step.tool,
+            args=dict(step.args),
+            guards=[],
+        )
+        for step in chain.steps
+    ]
+    context = {
+        "request_id": chain.request_id,
+        "scene_id": chain.scene_id,
+    }
+    if chain.actor_id is not None:
+        context["actor_id"] = chain.actor_id
+    return ExecutionRequest(plan_id=plan_id, steps=steps, context=context)
+
+
+def tool_chain_from_execution_request(req: ExecutionRequest) -> ToolCallChain:
+    request_id = str(req.context.get("request_id", req.plan_id))
+    scene_id = int(req.context.get("scene_id", 0))
+    actor_id = req.context.get("actor_id")
+    steps = [
+        ToolStep(tool=step.op, args=dict(step.args), requires_confirmation=True)
+        for step in req.steps
+    ]
+    return ToolCallChain(request_id=request_id, scene_id=scene_id, steps=steps, actor_id=actor_id)

--- a/src/Adventorator/commands/plan.py
+++ b/src/Adventorator/commands/plan.py
@@ -7,6 +7,7 @@ import structlog
 from pydantic import Field
 
 from Adventorator import repos
+from Adventorator.action_validation import plan_from_planner_output, plan_registry
 from Adventorator.commanding import Invocation, Option, find_command, slash_command
 from Adventorator.db import session_scope
 from Adventorator.metrics import inc_counter
@@ -132,6 +133,7 @@ async def plan_cmd(inv: Invocation, opts: PlanOpts):
     cmd_name_flat = target_top + (f".{target_sub}" if target_sub else "")
     if not _is_allowed(cmd_name_flat):
         inc_counter("planner.decision.rejected")
+        inc_counter("planner.allowlist.rejected")
         log.info(
             "planner.decision",
             cmd=cmd_name_flat,
@@ -191,6 +193,12 @@ async def plan_cmd(inv: Invocation, opts: PlanOpts):
         confidence=getattr(out, "confidence", None),
         rationale=(getattr(out, "rationale", None) or "")[:120],
     )
+
+    if getattr(settings, "features_action_validation", False):
+        plan_obj = plan_from_planner_output(out)
+        plan_registry.register_plan(plan_obj)
+        inc_counter("plan.steps.count", len(plan_obj.steps))
+        log.info("planner.plan.built", plan=plan_obj.model_dump())
 
     # Re-dispatch to the planned command handler with the SAME invocation context
     new_inv = Invocation(

--- a/src/Adventorator/config.py
+++ b/src/Adventorator/config.py
@@ -21,6 +21,9 @@ def _toml_settings_source() -> dict[str, Any]:
     out: dict[str, Any] = {
         "env": t.get("app", {}).get("env", "dev"),
         "features_llm": t.get("features", {}).get("llm", False),
+        "features_action_validation": t.get("features", {}).get("action_validation", False),
+        "features_predicate_gate": t.get("features", {}).get("predicate_gate", False),
+        "features_mcp": t.get("features", {}).get("mcp", False),
         # Map rendering (Phase 12) — prefer [map].enabled with legacy fallback
         "features_map": bool(
             (t.get("map", {}) or {}).get(
@@ -28,15 +31,15 @@ def _toml_settings_source() -> dict[str, Any]:
                 (t.get("features", {}) or {}).get("map", False),
             )
         ),
-    # Default visibility to False for safe-by-default shadow mode
-    "features_llm_visible": t.get("features", {}).get("llm_visible", False),
-    # Planner hard-toggle; prefer [planner].enabled, fallback to legacy [features].planner
-    "feature_planner_enabled": bool(
-        (t.get("planner", {}) or {}).get(
-            "enabled",
-            (t.get("features", {}) or {}).get("planner", True),
-        )
-    ),
+        # Default visibility to False for safe-by-default shadow mode
+        "features_llm_visible": t.get("features", {}).get("llm_visible", False),
+        # Planner hard-toggle; prefer [planner].enabled, fallback to legacy [features].planner
+        "feature_planner_enabled": bool(
+            (t.get("planner", {}) or {}).get(
+                "enabled",
+                (t.get("features", {}) or {}).get("planner", True),
+            )
+        ),
         "features_rules": t.get("features", {}).get("rules", False),
         # Combat FF now lives under [combat].enabled; keep a fallback to legacy [features].combat
         # Example:
@@ -51,16 +54,16 @@ def _toml_settings_source() -> dict[str, Any]:
                 (t.get("features", {}) or {}).get("combat", False),
             )
         ),
-    # Events ledger (Phase 9) — default disabled
-    "features_events": t.get("features", {}).get("events", False),
-    # Executor (Phase 7+) — default disabled
-    "features_executor": t.get("features", {}).get("executor", False),
-    # Confirmation gating FF (Phase 8); default true so it can be disabled in dev
-    "features_executor_confirm": t.get("features", {}).get("executor_confirm", True),
-    "response_timeout_seconds": t.get("discord", {}).get("response_timeout_seconds", 3),
-    # When set, app will post follow-ups to this base URL instead of Discord.
-    # Example: "http://host.docker.internal:19000"
-    "discord_webhook_url_override": t.get("discord", {}).get("webhook_url_override"),
+        # Events ledger (Phase 9) — default disabled
+        "features_events": t.get("features", {}).get("events", False),
+        # Executor (Phase 7+) — default disabled
+        "features_executor": t.get("features", {}).get("executor", False),
+        # Confirmation gating FF (Phase 8); default true so it can be disabled in dev
+        "features_executor_confirm": t.get("features", {}).get("executor_confirm", True),
+        "response_timeout_seconds": t.get("discord", {}).get("response_timeout_seconds", 3),
+        # When set, app will post follow-ups to this base URL instead of Discord.
+        # Example: "http://host.docker.internal:19000"
+        "discord_webhook_url_override": t.get("discord", {}).get("webhook_url_override"),
         "llm_api_provider": t.get("llm", {}).get("api_provider", "ollama"),
         "llm_api_url": t.get("llm", {}).get("api_url"),
         "llm_model_name": t.get("llm", {}).get("model_name"),
@@ -68,10 +71,10 @@ def _toml_settings_source() -> dict[str, Any]:
         # Logging config
         "logging_enabled": t.get("logging", {}).get("enabled", True),
         "logging_level": t.get("logging", {}).get("level", "INFO"),
-    # Per-handler levels: strings INFO|DEBUG|WARNING|ERROR|CRITICAL|NONE
-    # Backward-compatible: if console/to_file are bools, map True->level, False->NONE
-    "logging_console": None,
-    "logging_file": None,
+        # Per-handler levels: strings INFO|DEBUG|WARNING|ERROR|CRITICAL|NONE
+        # Backward-compatible: if console/to_file are bools, map True->level, False->NONE
+        "logging_console": None,
+        "logging_file": None,
         "logging_file_path": t.get("logging", {}).get("file_path", "logs/adventorator.jsonl"),
         "logging_max_bytes": t.get("logging", {}).get("max_bytes", 5_000_000),
         "logging_backup_count": t.get("logging", {}).get("backup_count", 5),
@@ -150,6 +153,9 @@ class Settings(BaseSettings):
     feature_planner_enabled: bool = True
     features_rules: bool = False
     features_combat: bool = False
+    features_action_validation: bool = False
+    features_predicate_gate: bool = False
+    features_mcp: bool = False
     features_map: bool = False
     features_events: bool = False
     features_executor: bool = False

--- a/src/Adventorator/metrics.py
+++ b/src/Adventorator/metrics.py
@@ -40,6 +40,12 @@ def reset_counters() -> None:
     except Exception:
         # If planner isn't importable in some contexts, ignore silently.
         pass
+    try:
+        from Adventorator.action_validation import plan_registry
+
+        plan_registry.reset()
+    except Exception:
+        pass
 
 
 def get_counters() -> dict[str, int]:

--- a/tests/test_action_validation_schemas.py
+++ b/tests/test_action_validation_schemas.py
@@ -1,0 +1,43 @@
+from Adventorator.action_validation import (
+    ExecutionRequest,
+    Plan,
+    PlanStep,
+    execution_request_from_tool_chain,
+    plan_from_planner_output,
+    planner_output_from_plan,
+    tool_chain_from_execution_request,
+)
+from Adventorator.executor import ToolCallChain, ToolStep
+from Adventorator.planner_schemas import PlannerOutput
+
+
+def test_planner_round_trip_identity():
+    original = PlannerOutput(command="roll", subcommand=None, args={"expr": "1d20"})
+    plan = plan_from_planner_output(original)
+    assert isinstance(plan, Plan)
+    assert plan.feasible is True
+    assert plan.steps == [PlanStep(op="roll", args={"expr": "1d20"}, guards=[])]
+
+    round_trip = planner_output_from_plan(plan)
+    assert round_trip == original
+
+
+def test_executor_round_trip_identity():
+    chain = ToolCallChain(
+        request_id="req-1",
+        scene_id=42,
+        steps=[
+            ToolStep(tool="check", args={"ability": "DEX", "dc": 12}, requires_confirmation=True),
+            ToolStep(tool="attack", args={"target": "goblin"}, requires_confirmation=False),
+        ],
+    )
+    req = execution_request_from_tool_chain(chain, plan_id="plan-abc")
+    assert isinstance(req, ExecutionRequest)
+    assert req.context["scene_id"] == 42
+    restored = tool_chain_from_execution_request(req)
+    assert restored.request_id == chain.request_id
+    assert restored.scene_id == chain.scene_id
+    assert [step.tool for step in restored.steps] == ["check", "attack"]
+    assert restored.steps[0].args == chain.steps[0].args
+    assert restored.steps[0].requires_confirmation is True
+    assert restored.actor_id == chain.actor_id

--- a/tests/test_orchestrator_attack.py
+++ b/tests/test_orchestrator_attack.py
@@ -24,7 +24,7 @@ class FakeLLM:
 @pytest.mark.asyncio
 async def test_orchestrator_attack_preview_and_chain(monkeypatch):
     # Enable executor preview path
-    settings = type("S", (), {"features_executor": True})()
+    settings = type("S", (), {"features_executor": True, "features_action_validation": True})()
 
     out = LLMOutput(
         proposal=LLMProposal(
@@ -56,6 +56,8 @@ async def test_orchestrator_attack_preview_and_chain(monkeypatch):
     assert res.chain_json is not None
     steps = res.chain_json.get("steps")
     assert steps and steps[0]["tool"] == "attack"
+    assert res.execution_request is not None
+    assert res.execution_request.steps[0].op == "attack"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add action validation schemas, converters, and registry scaffolding
- surface new action-validation feature flags and log plan steps during /plan routing
- teach the orchestrator to emit execution requests and cover new flows with tests

## Testing
- pytest tests/test_action_validation_schemas.py tests/test_orchestrator_attack.py tests/test_plan_integration.py tests/test_plan_more_integration.py tests/test_planner.py

------
https://chatgpt.com/codex/tasks/task_e_68cc61b4744083238925b6c01f8064c2