### PR TITLE
feat: phase3 execution request orchestration

### DIFF
--- a/src/Adventorator/commands/plan.py
+++ b/src/Adventorator/commands/plan.py
@@ -116,8 +116,6 @@ async def plan_cmd(inv: Invocation, opts: PlanOpts):
         except Exception:
             plan_obj = None
             out = None
-        else:
-            inc_counter("planner.cache.hit")
     else:
         # Plan using LLM with a soft timeout; fallback to roll 1d20 on timeout
         try:

--- a/src/Adventorator/orchestrator.py
+++ b/src/Adventorator/orchestrator.py
@@ -275,7 +275,10 @@ async def run_orchestrator(
 
     # Cache check to control duplicate prompts spam
     _orc_start = time.monotonic()
-    cache_key = (scene_id, player_msg.strip())
+    feature_action_validation = bool(
+        getattr(settings, "features_action_validation", False) if settings is not None else False
+    )
+    cache_key = (scene_id, player_msg.strip(), feature_action_validation)
     now = time.time()
     execution_request: ExecutionRequest | None = None
     request_id_seed = int(now * 1000)
@@ -533,7 +536,7 @@ async def run_orchestrator(
         if actor_id is not None:
             ctx["actor_id"] = actor_id
         req_for_execution = ExecutionRequest(plan_id=ctx["request_id"], steps=plan_steps, context=ctx)
-        if getattr(settings, "features_action_validation", False):
+        if feature_action_validation:
             execution_request = req_for_execution
 
     if use_executor and (_executor_mod is not None) and hasattr(_executor_mod, "Executor"):

--- a/src/Adventorator/planner.py
+++ b/src/Adventorator/planner.py
@@ -63,6 +63,12 @@ def _cache_get(scene_id: int, msg: str) -> tuple[dict[str, Any], str] | None:
         return None
     entry = _normalize_cache_entry(key, v)
     if now - entry.timestamp <= _CACHE_TTL:
+        try:
+            from Adventorator.metrics import inc_counter  # local import to avoid cycles
+
+            inc_counter("planner.cache.hit")
+        except Exception:  # pragma: no cover - defensive, metrics optional in tests
+            pass
         return entry.payload, entry.schema
     return None
 

--- a/tests/test_orchestrator_phase3.py
+++ b/tests/test_orchestrator_phase3.py
@@ -1,0 +1,122 @@
+import pytest
+
+from Adventorator.metrics import get_counter, reset_counters
+from Adventorator.orchestrator import OrchestratorResult, run_orchestrator
+from Adventorator.schemas import LLMOutput, LLMProposal
+
+
+def _neutral_sheet(_ability: str):
+    return {
+        "score": 10,
+        "proficient": False,
+        "expertise": False,
+        "prof_bonus": 2,
+    }
+
+
+class FakeLLM:
+    def __init__(self, output: LLMOutput | None):
+        self._out = output
+
+    async def generate_json(self, _messages, system_prompt=None):  # noqa: ANN001
+        return self._out
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_rejects_banned_reason_has_reason_and_counter(monkeypatch):
+    reset_counters()
+    settings = type(
+        "Settings",
+        (),
+        {
+            "features_executor": False,
+            "features_action_validation": True,
+        },
+    )()
+
+    out = LLMOutput(
+        proposal=LLMProposal(
+            action="ability_check",
+            ability="DEX",
+            suggested_dc=12,
+            reason="We should apply damage to the foe.",
+        ),
+        narration="A burst of energy applies damage everywhere.",
+    )
+
+    llm = FakeLLM(out)
+
+    res = await run_orchestrator(
+        scene_id=99,
+        player_msg="I want to roll",
+        sheet_info_provider=_neutral_sheet,
+        rng_seed=7,
+        llm_client=llm,
+        settings=settings,
+        actor_id="actor-1",
+    )
+
+    assert isinstance(res, OrchestratorResult)
+    assert res.rejected is True
+    assert res.reason == "unsafe_verb"
+    assert res.execution_request is None
+    assert get_counter("llm.defense.rejected") == 1
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_execution_request_only_with_feature_flag(monkeypatch):
+    reset_counters()
+    settings = type(
+        "Settings",
+        (),
+        {
+            "features_executor": False,
+            "features_action_validation": False,
+        },
+    )()
+
+    out = LLMOutput(
+        proposal=LLMProposal(
+            action="ability_check",
+            ability="INT",
+            suggested_dc=10,
+            reason="Consider the arcane symbols carefully.",
+        ),
+        narration="You study the runes intently.",
+    )
+
+    llm = FakeLLM(out)
+
+    res = await run_orchestrator(
+        scene_id=22,
+        player_msg="I investigate",
+        sheet_info_provider=_neutral_sheet,
+        rng_seed=11,
+        llm_client=llm,
+        settings=settings,
+        actor_id="actor-2",
+    )
+
+    assert isinstance(res, OrchestratorResult)
+    assert res.rejected is False
+    assert res.execution_request is None
+    # Mechanics text is still produced
+    assert "Check" in res.mechanics
+
+    # Enabling the flag produces an ExecutionRequest
+    settings.features_action_validation = True
+
+    res_flagged = await run_orchestrator(
+        scene_id=22,
+        player_msg="I investigate again",
+        sheet_info_provider=_neutral_sheet,
+        rng_seed=11,
+        llm_client=llm,
+        settings=settings,
+        actor_id="actor-2",
+    )
+
+    assert res_flagged.execution_request is not None
+    assert res_flagged.execution_request.steps
+    assert res_flagged.execution_request.steps[0].op == "check"
+


### PR DESCRIPTION
## Summary
- ensure orchestrator cache keys account for the action validation flag and only surface ExecutionRequest when enabled
- count planner cache hits inside the planner cache helper instead of plan_cmd
- add coverage for Phase 3 behaviour including rejection reasons, feature-flag gating, and cache metrics

## Testing
- pytest tests/test_orchestrator_phase3.py tests/test_orchestrator_attack.py::test_orchestrator_attack_preview_and_chain tests/test_plan_cache_metric.py::test_plan_planner_cache_hit_increments -q

------
https://chatgpt.com/codex/tasks/task_e_68cc7d80b8748323ba19bd6ca13019fb