### PR TITLE
docs: relocate ai dev pipeline plan

### DIFF
--- a/docs/implementation/aidd-plan.md
+++ b/docs/implementation/aidd-plan.md
@@ -1,0 +1,62 @@
+# Implementation Plans
+
+## Align Adventorator with AI Development Pipeline
+
+### Overview
+The AI-driven development pipeline emphasizes tight traceability from Feature Epics down to per-prompt Tasks, contract-first delivery, and automated quality gates spanning ADR conformance, testing, and AI evaluation. Adventorator already has rich documentation and modular architecture, but its current structure does not yet follow the Epic → Story → Task workflow or enforce the prescribed governance artifacts and CI checks.
+
+### Current State Assessment
+- **Documentation & Architecture:** Adventorator’s README describes core architecture, feature flags, and operational flows, yet there is no dedicated ADR catalog or C4 overview aligned with Feature Epics.
+- **Repo Layout:** Directories such as `docs/`, `migrations/`, and `src/` cover implementation and developer notes, but there are no canonical locations for contracts, prompts, or story/task plans as suggested by the pipeline framework.
+- **Process Assets:** GitHub issue/PR templates, quality gate workflows, and prompt registries from the pipeline are absent, limiting traceability and automated policy enforcement.
+
+### Implementation Plan
+
+#### Phase 1 – Governance Foundations
+1. **Define Artifact Structure**
+   - Create `docs/adr/` seeded with the ADR template to record decisions linked to architecture and feature work.
+   - Stand up `docs/architecture/` (or similar) for C4 diagrams and epic-level architecture overviews referenced in Feature Epics.
+2. **Establish Prompt & Contract Registries**
+   - Add `prompts/` with semantic versioning for AI prompts to align with the framework’s prompt registry guidance.
+   - Introduce `contracts/` (and/or `openapi/`, `proto/`) to host API/interface schemas, ensuring future stories and tasks work contract-first.
+3. **Adopt Issue & PR Templates**
+   - Install GitHub templates for Feature Epics, Stories, Tasks, and PRs using the pipeline-provided structures to enforce scope, acceptance criteria, and DoR/DoD fields.
+   - Wire templates into `.github/ISSUE_TEMPLATE/` and `.github/pull_request_template.md` for immediate usage.
+
+#### Phase 2 – Workflow & Traceability Enablement
+1. **Map Existing Roadmap Items**
+   - Convert ongoing initiatives (e.g., Encounter feature) into Feature Epics with linked Stories and Tasks, capturing objectives, risks, and traceability back to ADRs and architecture documents.
+2. **Draft Initial ADRs and C4 Models**
+   - For core systems (planner, orchestrator, executor), author ADRs summarizing current decisions and reference them from the new epics/stories.
+3. **Integrate Definition of Ready/Done**
+   - Embed DoR/DoD checklists from the templates into sprint rituals and review processes so stories and tasks meet contract, testing, and observability expectations before work starts and finishes.
+4. **Document Observability & Feature Flags**
+   - Enhance existing docs with observability budgets, metrics, and feature flag rollout/rollback plans to satisfy story-level requirements.
+
+#### Phase 3 – Quality Gates & Automation
+1. **Implement PR Quality Gate Workflow**
+   - Add the provided GitHub Actions workflow (`pr-quality-gates.yml`) to enforce Story/Task references and ADR linkage for architectural changes, tuning path regexes for Adventorator’s directory names.
+   - Extend the workflow with ADR linting to validate required headings and maintain ADR quality.
+2. **Extend CI for Coverage, Mutation, and AI Evaluations**
+   - Audit current CI pipelines and incorporate coverage, mutation testing, security scans, performance budgets, and AI eval checks per the quality gate recommendations.
+   - Define thresholds and integrate them into `Makefile`/CI targets to produce actionable failures for agents and humans.
+3. **Automate Prompt/Contract Validation**
+   - Add schema validators or golden test harnesses for prompts and contracts to support the contract-first, AI-evaluated workflow.
+
+#### Phase 4 – Cultural Adoption & Continuous Improvement
+1. **Run Pilot Epic**
+   - Select an upcoming feature, manage it end-to-end using the new Epic→Story→Task templates, and gather feedback from contributors and AI agents.
+2. **Retrospective & Refinement**
+   - Iterate on templates, ADR processes, and quality gate thresholds based on pilot findings, ensuring automation remains supportive and not obstructive.
+3. **Documentation & Onboarding**
+   - Update `README` and `CONTRIBUTING` to explain the new pipeline, referencing where to find templates, ADRs, prompts, and how to satisfy quality gates for newcomers and AI assistants.
+
+#### Phase 5 – Scaling & Governance
+1. **Establish Prompt & Model Governance**
+   - Build out evaluation suites, cost/latency budgets, and safety checks for AI components, aligning with the pipeline’s AI governance goals.
+2. **Introduce Metrics Dashboards**
+   - Leverage observability requirements to create dashboards/alerts that verify p95 latency, throughput, and token usage budgets, closing the loop with quality gates.
+3. **Regularly Audit Compliance**
+   - Schedule quarterly reviews of ADR coverage, template usage, and CI gate adherence to keep the process healthy as the codebase evolves.
+
+By executing these phases, Adventorator can align its structure and workflows with the AI-driven development pipeline, ensuring each change is traceable, contract-first, and validated by automated gates while supporting AI-assisted contributions.


### PR DESCRIPTION
## Summary
- move the AI development pipeline alignment plan into docs/implementation/aidd-plan.md

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cd7b43a28c83239d8140894e9ed34a