### PR TITLE
Clarify PR template requirements in agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,5 @@ These instructions apply to the entire repository.
 ## Pull requests & summaries
 - Summaries should highlight user-visible behavior changes, mention affected modules, and tie back to action-validation milestones when applicable.
 - If checks are skipped, call that out explicitly in the final response along with the reason.
+- When creating a PR with `make_pr`, copy the structure from [`.github/pull_request_template.md`](./.github/pull_request_template.md): include all headings, checklists, and placeholder guidance so reviewers receive the complete template.
+- Populate each checklist item with a checked (`- [x]`) or unchecked (`- [ ]`) box. Use `N/A` only inside the descriptive bullet text if something does not apply; do not delete template rows.


### PR DESCRIPTION
## Summary
- Explicitly instruct agents to replicate the pull request template when calling `make_pr`
- Require each checklist item to be marked and preserve all rows for reviewer clarity

## Related Work
- **Feature Epic(s):** N/A
- **Story(ies):** N/A
- **Task(s):** N/A
- **ADR(s):** N/A

## Architecture Impact
- [x] No architectural changes
- [ ] Yes, ADR(s) linked above

If "Yes," summarize:
- **Contracts/Interfaces Changed:** N/A
- **Persistence/Infra Changes:** N/A
- **New Dependencies:** N/A

## Tests & Quality Gates
- [ ] Unit tests added/updated (docs-only change)
- [ ] Property/contract tests added/updated (docs-only change)
- [ ] Integration tests added/updated (docs-only change)
- [ ] AI evals run (if applicable)
- [ ] Coverage ≥ target (docs-only change)
- [ ] Mutation score ≥ target (docs-only change)

## Observability & Ops
- [ ] Metrics/logs/traces updated (docs-only change)
- [ ] Alerts/dashboards updated (docs-only change)
- [ ] Runbooks updated (docs-only change)

## Checklist
- [x] Code follows style guidelines
- [x] Docs updated (README, ADRs, etc.)
- [ ] Feature behind a flag (N/A)
- [ ] Rollback plan documented (N/A)


------
https://chatgpt.com/codex/tasks/task_e_68cda919ba7c8323a8424eb9f0522089