### PR TITLE
Allow N/A for PR issue link checks

### DIFF
--- a/.github/workflows/pr-quality-gates.yml
+++ b/.github/workflows/pr-quality-gates.yml
@@ -27,15 +27,17 @@ jobs:
               }
             }
 
+            const isNotApplicable = (value) => value.trim().toLowerCase() === "n/a";
+
             const epicLine = /- \*\*Feature Epic\(s\):\*\*\s*(.+)/i.exec(body);
-            if (!epicLine || !/#\d+/.test(epicLine[1])) {
+            if (!epicLine || (!isNotApplicable(epicLine[1]) && !/#\d+/.test(epicLine[1]))) {
               errors.push("Link at least one Feature Epic issue using '#<number>'.");
             }
 
             const storyLine = /- \*\*Story\(ies\):\*\*\s*(.+)/i.exec(body);
             const taskLine = /- \*\*Task\(s\):\*\*\s*(.+)/i.exec(body);
-            const storyHasRef = storyLine && /#\d+/.test(storyLine[1]);
-            const taskHasRef = taskLine && /#\d+/.test(taskLine[1]);
+            const storyHasRef = storyLine && (isNotApplicable(storyLine[1]) || /#\d+/.test(storyLine[1]));
+            const taskHasRef = taskLine && (isNotApplicable(taskLine[1]) || /#\d+/.test(taskLine[1]));
             if (!storyHasRef && !taskHasRef) {
               errors.push("Reference at least one Story or Task issue in the PR body.");
             }


### PR DESCRIPTION
## Summary
- allow `N/A` entries in PR metadata checks so optional issue links no longer fail quality gates

## Related Work
- **Feature Epic(s):** N/A
- **Story(ies):** N/A
- **Task(s):** N/A
- **ADR(s):** N/A

## Architecture Impact
- [x] No architectural changes
- [ ] Yes, ADR(s) linked above

If "Yes," summarize:
- **Contracts/Interfaces Changed:**
- **Persistence/Infra Changes:**
- **New Dependencies:**

## Tests & Quality Gates
- [ ] Unit tests added/updated
- [ ] Property/contract tests added/updated
- [ ] Integration tests added/updated
- [ ] AI evals run (if applicable)
- [ ] Coverage ≥ target
- [ ] Mutation score ≥ target

## Observability & Ops
- [ ] Metrics/logs/traces updated
- [ ] Alerts/dashboards updated
- [ ] Runbooks updated

## Checklist
- [x] Code follows style guidelines
- [ ] Docs updated (README, ADRs, etc.)
- [ ] Feature behind a flag
- [ ] Rollback plan documented

------
https://chatgpt.com/codex/tasks/task_e_68cdaaa291588323a93c4b679321c687