### PR TITLE
docs(cda): campaign data architecture & importer/substrate epics alignment

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,10 +46,11 @@ Authoritative sources of truth:
 ## 5. Extended World & Content (Phases 6, 12–14) — Mixed Status
 | Phase | Status | Scope |
 |-------|--------|-------|
-| Content Retrieval (Phase 6) | ✅ Complete | Ingestion & retrieval context bundling (now historical; may evolve under future ingestion epic). |
+| Content Retrieval (Phase 6) | ✅ Complete | Retrieval context bundling (pre-CDA; superseded by ARCH-CDA-001 package import model). |
 | Map Rendering MVP (Phase 12) | 🛣️ Planned | Static rendered encounter map via Pillow with cache invalidation. |
 | Modal Scenes (Phase 13) | 🛣️ Planned | Exploration ↔ combat branching & merge semantics. |
-| Campaign & Character Ingestion (Phase 14) | 🛣️ Planned | Structured import with preview-confirm tool chain. |
+| Campaign Package Import (EPIC-CDA-IMPORT-002) | 🔄 In Progress | Deterministic manifest/entity/edge/tag/chunk import + synthetic seed events (see ADR-0011, ARCH-CDA-001). |
+| Character Import / Sheet Normalization (Phase 14) | 🛣️ Planned | Structured character sheet ingestion building atop provenance & ImportLog patterns. |
 
 ## 6. GM Controls & Operational Hardening (Phases 15–16) — 🛣️ Planned
 | Phase | Status | Scope |
@@ -60,8 +61,11 @@ Authoritative sources of truth:
 ## 7. Cross-Cutting Epics — 🔄 / 🛣️
 | Epic | Status | Purpose |
 |------|--------|---------|
-| Action Validation (EPIC-AVA-001) | 🔄 Maturing | Planner → Orchestrator → Executor validation chain (see ADR-0001, ADR-0003, ADR-0004) with ActivityLog dependency. |
-| Activity Log Mechanics Ledger (EPIC-ACTLOG-001) | 🛣️ Planned | Unified auditable mechanics ledger (taxonomy, schema, determinism, metrics). |
+| Action Validation (EPIC-AVA-001) | 🔄 Maturing | Planner → Orchestrator → Executor validation chain (ADR-0001, ADR-0003, ADR-0004) with ActivityLog dependency. |
+| Mechanics Activity Log (EPIC-ACTLOG-001) | 🛣️ Planned | Unified auditable mechanics ledger (taxonomy, schema, determinism, metrics). |
+| Deterministic Event Substrate (EPIC-CDA-CORE-001) | 🔄 In Progress | Canonical JSON encoder, hash chain, idempotency, metrics (ADR-0006, ADR-0007, ARCH-CDA-001). |
+| Campaign Package Import & Provenance (EPIC-CDA-IMPORT-002) | 🔄 In Progress | Deterministic package ingest + synthetic seed events + ImportLog (ADR-0011, ARCH-CDA-001). |
+| Campaign Data Architecture (ARCH-CDA-001) | 🛣️ Planned | Unified event-sourced world model (ledger, importer, RNG, snapshots, provenance). |
 
 ## 8. Feature Flag Overview
 | Flag | Default | Purpose |
@@ -77,10 +81,12 @@ Authoritative sources of truth:
 | (See `config.toml` for authoritative list) |  |  |
 
 ## 9. Current Focus & Near-Term Priorities
-1. Stand up ActivityLog epic scaffolding (issues, tasks, CI traceability integration).
-2. Prepare map rendering MVP (benchmark render latency + snapshot tests).
-3. Define ingestion/import preview-confirm tool patterns (Phase 14 alignment with executor).
-4. Introduce GM remediation tools atop event ledger (rewind primitives). 
+1. Advance EPIC-CDA-CORE-001 (hash chain logic, canonical encoder vectors, idempotency helper tests).
+2. Execute EPIC-CDA-IMPORT-002 phases (manifest → entities → edges → ontology → lore → finalize) with deterministic ordering & seed events.
+3. Stand up ActivityLog (EPIC-ACTLOG-001) issue scaffolding to unblock Action Validation audit requirements.
+4. Prepare map rendering MVP (benchmark render latency + snapshot tests).
+5. Define character import schema (Phase 14) leveraging provenance & ImportLog patterns.
+6. Introduce GM remediation tools atop event ledger (rewind primitives). 
 
 ## 10. Future / Intent (Exploratory — 🧭)
 These are directional concepts not yet scheduled

--- a/docs/adr/ADR-0004-mcp-adapter-architecture.md
+++ b/docs/adr/ADR-0004-mcp-adapter-architecture.md
@@ -7,7 +7,7 @@ ADR-0004 — MCP adapter architecture for Action Validation executor integration
 Accepted — 2025-02-14 (Owner: Action Validation Working Group)
 
 ## Context
-Phase 7 of [EPIC-AVA-001 — Action Validation Pipeline Enablement](../implementation/epics/EPIC-AVA-001-action-validation-architecture.md) requires STORY-AVA-001H to introduce Multi-Component Protocol (MCP) adapters so the executor can route deterministic tool calls through a swap-friendly interface. Today the executor directly invokes rules and simulation helpers, bypassing the MCP contracts documented in [ARCH-AVA-001 — Action Validation Architecture](../architecture/action-validation-architecture.md). Only the `features.mcp` flag exists; no adapter modules, contracts, or tests enforce parity with the existing tool chain behavior. We must define the in-process MCP architecture now to unblock adapter scaffolding while keeping forward compatibility for future out-of-process MCP servers.
+Phase 7 of [EPIC-AVA-001 — Action Validation Pipeline Enablement](../implementation/epics/EPIC-AVA-001-action-validation-architecture.md) requires STORY-AVA-001H to introduce Multi-Component Protocol (MCP) adapters so the executor can route deterministic tool calls through a swap-friendly interface. Today the executor directly invokes rules and simulation helpers, bypassing the MCP contracts documented in [ARCH-AVA-001 — Action Validation Architecture](../architecture/ARCH-AVA-001-action-validation-architecture.md). Only the `features.mcp` flag exists; no adapter modules, contracts, or tests enforce parity with the existing tool chain behavior. We must define the in-process MCP architecture now to unblock adapter scaffolding while keeping forward compatibility for future out-of-process MCP servers.
 
 ## Decision
 - Introduce a dedicated MCP client layer inside the executor that mediates all tool execution when `features.mcp` is enabled. The client wraps each `ExecutionRequest` step, resolves the correct MCP adapter, and handles retry/metrics concerns before delegating to the underlying server shim. (Implemented in `src/Adventorator/mcp/client.py`.)
@@ -44,7 +44,7 @@ Phase 7 of [EPIC-AVA-001 — Action Validation Pipeline Enablement](../implement
 
 ## References
 - [EPIC-AVA-001 — Action Validation Pipeline Enablement](../implementation/epics/EPIC-AVA-001-action-validation-architecture.md)
-- [ARCH-AVA-001 — Action Validation Architecture](../architecture/action-validation-architecture.md)
+- [ARCH-AVA-001 — Action Validation Architecture](../architecture/ARCH-AVA-001-action-validation-architecture.md)
 - [STORY-AVA-001H — MCP adapter scaffold](../implementation/epics/EPIC-AVA-001-action-validation-architecture.md#story-ava-001h--mcp-adapter-scaffold)
 - [Manual validation runbook for EPIC-AVA-001](../smoke/manual-validation-EPIC-AVA-001.md)
 - [`docs/implementation/action-validation-implementation.md` — Phase 7 MCP scaffold requirements](../implementation/action-validation-implementation.md#phase-7--mcp-scaffold-local-in-process-servers)

--- a/docs/adr/ADR-0006-event-envelope-and-hash-chain.md
+++ b/docs/adr/ADR-0006-event-envelope-and-hash-chain.md
@@ -1,0 +1,41 @@
+# ADR-0006 Deterministic Event Envelope & Hash Chain
+
+Status: Proposed  
+Date: 2025-09-21  
+Related Architecture: ARCH-CDA-001, ARCH-AVA-001  
+Traceability: Referenced by [ARCH-CDA-001](../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+
+## Context
+Legacy events lacked a canonical serialization, deterministic ordering guarantees, or tamper-evident chaining. Auditability and replay fidelity require an immutable, verifiable event ledger.
+
+## Decision
+Adopt an extended event envelope:
+- Dense `replay_ordinal` (unique, gap-free per campaign).
+- Hash chain: `prev_event_hash` (32 zero bytes for genesis) + `payload_hash` (SHA-256 canonical JSON).
+- Canonical JSON (see ADR-0007) for payload hashing.
+- Idempotency key (first 16 bytes of composite SHA-256) prevents duplicate application.
+- Genesis event `campaign.genesis` has published expected hash.
+- DB constraints: unique (campaign_id, replay_ordinal) and (campaign_id, idempotency_key).
+
+## Consequences
+Pros:
+- Strong tamper evidence.
+- Deterministic replay enables reproducible state_digest.
+- Natural audit boundary for snapshot cuts.
+
+Cons:
+- Slight storage overhead (hash fields).
+- Requires strict encoder discipline.
+
+## Alternatives Rejected
+- Relying on auto-increment IDs (not gap-free).
+- Soft hash logging (no enforcement) — insufficient integrity guarantees.
+
+## Compliance / Enforcement
+- Alembic migration adds fields & constraints.
+- Trigger enforces dense replay_ordinal.
+- CI test: hash chain continuity + genesis hash match.
+
+## Follow-Up
+- Integrate hash chain verification in snapshot restore path.
+- Extend to compaction meta-events (reserved).

--- a/docs/adr/ADR-0007-canonical-json-numeric-policy.md
+++ b/docs/adr/ADR-0007-canonical-json-numeric-policy.md
@@ -1,0 +1,40 @@
+# ADR-0007 Canonical JSON & Numeric Policy
+
+Status: Proposed  
+Date: 2025-09-21  
+Depends On: ADR-0006  
+Traceability: Referenced by [ARCH-CDA-001](../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+
+## Context
+Hash stability requires canonical byte representation. JSON introduces ambiguity (key order, Unicode normalization, null handling, numeric formats).
+
+## Decision
+Canonicalization rules:
+- UTF-8 NFC normalization.
+- Sort object keys lexicographically (byte order).
+- Omit null fields.
+- Integers only (signed 64-bit). No floats in event payloads.
+- Fixed-point (scale 100) if decimal semantics required (store integer).
+- No scientific notation.
+- Booleans lowercase; arrays preserve order.
+- Large integers > 2^53-1 disallowed in mutation fields (must be strings in non-semantic props).
+- Hash: SHA-256 over canonical serialization.
+
+## Consequences
+Pros:
+- Stable hashing cross-platform.
+- Protects against subtle drift.
+
+Cons:
+- Additional encoder complexity.
+- Need explicit conversion for user-supplied floats.
+
+## Test Vectors
+10 fixtures stored under `tests/canonical_json/` (Unicode composition, large int edge, nested ordering).
+
+## Enforcement
+- Encoder utility used everywhere events hashed.
+- CI ensures diff against golden vectors.
+
+## Follow-Up
+- Add linter preventing raw `json.dumps` in critical paths.

--- a/docs/adr/ADR-0008-rng-streams-seed-derivation.md
+++ b/docs/adr/ADR-0008-rng-streams-seed-derivation.md
@@ -1,0 +1,31 @@
+# ADR-0008 RNG Streams & Seed Derivation
+
+Status: Proposed  
+Date: 2025-09-21  
+Depends On: ADR-0006, ADR-0007  
+Traceability: Referenced by [ARCH-CDA-001](../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+
+## Context
+Randomness must be reproducible for audits, drift detection, and fork equivalence.
+
+## Decision
+- Single campaign master seed (128-bit).
+- HKDF-SHA256 derivation per event with info: `"AV1|<ruleset_version>|<tool_version>|<stream>|<replay_ordinal_be8>"`.
+- Rolls derived deterministically (SHA256(base_seed||i)).
+- Record stream metadata + inputs + results in event payload.
+- No ambient RNG calls allowed in executor path.
+
+## Consequences
+Pros:
+- Full reproducibility.
+- Supports multi-stream isolation.
+
+Cons:
+- Tool authors must integrate helper explicitly.
+
+## Enforcement
+- Static analysis to detect `random` / `secrets` misuse.
+- Unit tests confirm deterministic roll sequences.
+
+## Future
+- Extend to simulation ticks (phase / turn) when added.

--- a/docs/adr/ADR-0009-capability-approval-enforcement.md
+++ b/docs/adr/ADR-0009-capability-approval-enforcement.md
@@ -1,0 +1,27 @@
+# ADR-0009 Capability & Approval Enforcement
+
+Status: Proposed  
+Date: 2025-09-21  
+Traceability: Referenced by [ARCH-CDA-001](../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+
+## Context
+Need permission boundaries (players vs GM vs system) and optional human-in-loop approvals for sensitive event types.
+
+## Decision
+- Roles, capabilities, role_capabilities, actor_role_assignments tables.
+- Tool → required_capabilities mapping.
+- Executor guards event emission; DB CHECK enforces approved_by presence when requires_approval.
+- Denies deferred (future explicit override layer).
+- Minimal seeded roles: player (limited), gm (superset), system (restricted internal operations).
+
+## Consequences
+Pros:
+- Clear least privilege model.
+- Audit trail of approvals.
+
+Cons:
+- Additional schema & join overhead.
+
+## Follow-Up
+- Add negative authorization layer (denies) post-MVP.
+- Health check validating role baseline.

--- a/docs/adr/ADR-0010-snapshot-fork-lineage.md
+++ b/docs/adr/ADR-0010-snapshot-fork-lineage.md
@@ -1,0 +1,26 @@
+# ADR-0010 Snapshot & Fork Lineage (No Merge)
+
+Status: Proposed  
+Date: 2025-09-21  
+Traceability: Referenced by [ARCH-CDA-001](../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+
+## Context
+Need branching for “what-if” / GM rehearsal without complexity of merges.
+
+## Decision
+- Fork = new campaign initialized from snapshot.
+- Branch lineage via parent_snapshot_id chain; no merge support.
+- replay_ordinal resets in fork.
+- Snapshots store state_digest + events_hash_chain_tip + logical_snapshot_hash.
+
+## Consequences
+Pros:
+- Simplifies audit logic.
+- Avoids merge conflicts complexity.
+
+Cons:
+- Duplicate storage for divergent forks.
+- No automated reconciliation.
+
+## Follow-Up
+- Evaluate cherry-pick meta-events when use-case volume justifies.

--- a/docs/adr/ADR-0011-package-import-provenance.md
+++ b/docs/adr/ADR-0011-package-import-provenance.md
@@ -1,0 +1,26 @@
+# ADR-0011 Package Import Provenance & Origin Metadata
+
+Status: Proposed  
+Date: 2025-09-21  
+Traceability: Referenced by [ARCH-CDA-001](../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+
+## Context
+Imported content must be traceable to immutable source files for reproducibility and trust.
+
+## Decision
+- Each entity/edge/chunk stores provenance: {package_id, source_path, file_hash}.
+- ImportLog records ordered deterministic steps (phase, object_type, stable_id).
+- Collision (same stable_id, different hash) hard-fails import.
+- Synthetic seed events mirror functional seed state (ImportLog for audit detail).
+- Signing & dependency resolution deferred but manifest fields reserved.
+
+## Consequences
+Pros:
+- Enables diffing across forks.
+- Assures integrity checks.
+
+Cons:
+- Slight storage overhead.
+
+## Follow-Up
+- Transparency log & signature policy ADR once registry introduced.

--- a/docs/adr/ADR-0012-event-versioning-migration-protocol.md
+++ b/docs/adr/ADR-0012-event-versioning-migration-protocol.md
@@ -1,0 +1,26 @@
+# ADR-0012 Event Versioning & Migration Protocol
+
+Status: Proposed  
+Date: 2025-09-21  
+Traceability: Referenced by [ARCH-CDA-001](../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+
+## Context
+Event schemas will evolve; must preserve replay capability without mutating stored historical payloads.
+
+## Decision
+- Registry: event_type → { latest_version, write_enabled, migrator_chain }.
+- Each event stores event_schema_version + migrator_applied_from (if upgraded during replay).
+- Migrations: pure, deterministic, no I/O, no clocks.
+- Write blocked if event_type write_enabled=false.
+- Golden corpus fixtures validated in CI after migrations.
+
+## Consequences
+Pros:
+- Non-destructive evolution.
+- Explicit deprecation path.
+
+Cons:
+- Additional maintenance overhead for migrators.
+
+## Follow-Up
+- Introduce tooling to auto-generate baseline migrator when bumping schema.

--- a/docs/architecture/ARCH-AVA-001-action-validation-architecture.md
+++ b/docs/architecture/ARCH-AVA-001-action-validation-architecture.md
@@ -1,5 +1,7 @@
 # ARCH-AVA-001 — Action Validation Architecture
 
+<!-- Moved from action-validation-architecture.md; filename updated for consistency with ARCH-* naming convention. -->
+
 **Status:** Active — Phases 0–6 implemented/in progress; remaining phases (7–9) planned behind feature flags  \
 **Last Updated:** 2025-09-19  \
 **Primary Epic:** [EPIC-AVA-001 — Action Validation Pipeline Enablement](../implementation/epics/EPIC-AVA-001-action-validation-architecture.md)  \
@@ -98,8 +100,8 @@ The Action Validation architecture introduces a modular, state-machine-driven pi
 
 ### Dual-Paradigm Validation
 
-* **Predicates (Mechanical Possibility):** Deterministic checks (`exists`, `reachable`, `dc_in_bounds`) answered via repos/rules modules, ensuring “can this happen?”.
-* **Semantic Tags (Narrative Plausibility):** Metadata describing magical, narrative, or contextual affordances to explore “does this make sense here?”.
+* **Predicates (Mechanical Possibility):** Deterministic checks (`exists`, `reachable`, `dc_in_bounds`) answered via repos/rules modules, ensuring "can this happen?".
+* **Semantic Tags (Narrative Plausibility):** Metadata describing magical, narrative, or contextual affordances to explore "does this make sense here?".
 
 ### Tiered Planning Strategy
 
@@ -168,7 +170,7 @@ class ExecutionResult:
 
 * **Ontology Management.** Store and version `AffordanceTags` alongside planner prompts and contracts.
 * **Configuration Management.** Externalise feature toggles (`features.action_validation`, `features.predicate_gate`, `features.mcp`) and planner/orchestrator timeouts.
-* **Observability.** Standardise structured logs, counters (`planner.feasible`, `predicate.gate.fail_reason`, `executor.preview/apply`), and ActivityLog records (Phase 6). Detailed mechanics ledger rollout tracked in [EPIC-ACTLOG-001](../implementation/epics/activitylog-mechanics-ledger.md).
+* **Observability.** Standardise structured logs, counters (`planner.feasible`, `predicate.gate.fail_reason`, `executor.preview/apply`), and ActivityLog records (Phase 6). Detailed mechanics ledger rollout tracked in [EPIC-ACTLOG-001](../implementation/epics/EPIC-ACTLOG-001-activitylog-mechanics-ledger.md).
 
 ## Traceability and Roadmap Alignment
 

--- a/docs/architecture/ARCH-CDA-001-campaign-data-architecture.md
+++ b/docs/architecture/ARCH-CDA-001-campaign-data-architecture.md
@@ -1,0 +1,543 @@
+# ARCH-CDA-001 — Campaign Data & Deterministic World State Architecture
+
+Status: Proposed (MVP scope locked)  
+Last Updated: 2025-09-21  
+Related Architecture: ARCH-AVA-001 (Action Validation Pipeline)  
+Supersedes / Extends: Implicit legacy “flat tables as state” model (no prior ADR)  
+Primary Audience: Engine / Rules / Persistence / AI pipeline contributors  
+
+---
+
+## 1. Executive Summary
+
+This document defines the deterministic, auditable foundation for campaign world state powering the `/ask → /plan → /do` action‑validation pipeline (ARCH-AVA-001).  
+Core shift: move from “current DB rows = mutable truth” to a triad:
+
+1. Immutable Campaign Package (seed provenance).
+2. Append‑only Event Ledger (single mutation choke‑point: Executor).
+3. Replayable Object Tree Projections + verifiable Snapshots (deterministic derived state).
+
+This enables:
+- Full audit / replay / fork.
+- Deterministic RNG & canonical hashing.
+- Contract-first evolution with event schema versioning.
+- Capability/approval enforcement & feature‑flagged rollout.
+- Future planner tiers and HTN expansion without state model churn.
+
+---
+
+## 2. High-Level Goals & Constraints
+
+| Goal | Mechanism |
+|------|-----------|
+| Deterministic replay | Canonical JSON + dense replay_ordinal + hash chain |
+| Audit-grade lineage | Origin metadata (package_id, source_path, file_hash) + import log + plan/execution FKs |
+| Single writer safety | Executor-only event emission; planner/orchestrator read-only |
+| Forkable worlds | Snapshot-based branching (no merge in MVP) |
+| RNG reproducibility | Campaign-level seed + HKDF stream derivation |
+| Strict contracts | JSON Schemas in `contracts/` + schema registry + parity CI |
+| Observability & drift detection | Hash chain, idempotency keys, preview vs applied hash |
+| Incremental extensibility | Reserved fields (phase_id, future beliefs store, compaction meta-event) |
+
+Non-goals (MVP):
+- Merge / cherry-pick of branches.
+- Fog-of-war belief persistence (derive only).
+- Physical (pre-materialized) snapshots (triggered later by SLO breach).
+- Prompt-injection quarantine (basic audience gating only).
+- Event compaction / pruning (reserved, not executed).
+
+---
+
+## 3. Core Representations
+
+### 3.1 Campaign Package (Immutable Seed)
+Filesystem bundle or registry artifact:
+- `package.manifest.json` (versioned, signed, dependency-locked).
+- `entities/` (Actor, Item, Space, Faction, Scene, RuleVariant).
+- `edges/` (containment, adjacency, membership, bindings).
+- `lore/` Markdown + front-matter (chunking hints, tags, audience).
+- `ontologies/` (Tag taxonomy + Affordance definitions).
+- Contracts snapshot (hash-pinned schemas).
+- Optional recommended feature flag defaults (advisory only).
+
+Manifest Key Fields:
+```
+package_id (ULID)
+schema_version
+engine_contract_range
+signatures[]
+dependencies[]
+content_index (hash per file)
+recommended_flags{}
+ruleset_version
+```
+
+Deterministic Import:
+Lexicographic ordering over (kind, stable_id). Synthetic `seed.*` events emitted; ImportLog retains audit granularity, but events alone suffice for replay.
+
+### 3.2 Event Ledger (Authoritative Mutation History)
+Append-only; each event envelope fields (MVP):
+
+```
+event_id (DB PK)
+campaign_id (FK)
+replay_ordinal (dense int, starts at 1 after genesis)
+event_type
+event_schema_version
+world_time (ticks; may == replay_ordinal early)
+wall_time_utc (audit)
+prev_event_hash (SHA-256, 32 bytes; zeros for genesis)
+payload_hash (canonical payload)
+idempotency_key (16 bytes prefix of SHA-256 composite)
+actor_id (FK actor/system)
+plan_id (FK plans)
+execution_request_id (FK execution_requests)
+approved_by (nullable FK; required if requires_approval)
+payload (JSON)
+migrator_applied_from (nullable)
+```
+
+Deterministic invariants:
+- Unique (campaign_id, replay_ordinal).
+- Gap-free replay_ordinal (trigger enforces `new.replay_ordinal = last + 1`).
+- Hash chain continuity (prev_event_hash == previous payload chain tip).
+- Idempotency uniqueness (campaign scope).
+- No floats / NaN / Infinity in payload (schema & encoder guard).
+
+Genesis:
+- `event_type = campaign.genesis`
+- `prev_event_hash = 00…00`
+- `payload = {}` (empty canonical object)
+- Expected hash published in [ADR-0006](../adr/ADR-0006-event-envelope-and-hash-chain.md).
+
+### 3.3 Object Tree (Derived Projections)
+In-memory / optionally persisted read models built by folding events over seed:
+- by_id: entity
+- by_tag: tag → entity_ids
+- containment_map: parent → children
+- adjacency: space → neighbors
+- actor_presence: scene → actor_ids (from movement / spawn events)
+- affordances_index: entity_id → affordance tags
+- retrieval_index: chunk_id → embeddings / metadata (audience enforced)
+
+Projection regeneration:
+- Full fold on restore.
+- Incremental update per new event (reducers pure + deterministic).
+- Validation hash: `state_digest = H(sorted(entity_id || entity_hash))`.
+
+### 3.4 Snapshot (Logical)
+Captures deterministic cut:
+```
+snapshot_id (ULID)
+campaign_id
+cutoff_event_id
+cutoff_replay_ordinal
+parent_snapshot_id (branch lineage)
+package_manifest_hash
+events_hash_chain_tip
+state_digest
+logical_snapshot_hash (self-hash; excludes this field in computation)
+signature (optional ED25519)
+key_id
+created_at
+```
+Restore:
+1. Load manifest (must match hash).
+2. Replay seed events + subsequent events up to cutoff.
+3. Recompute state_digest; assert equality.
+
+Physical snapshot deferred; when implemented must embed `logical_snapshot_hash`.
+
+---
+
+## 4. Domain Model Essentials
+
+Core entity canonical shape (runtime mirror of contract):
+```
+Entity {
+  stable_id (ULID)
+  kind (actor|item|space|faction|scene|rule_variant)
+  name
+  tags[]
+  affordances[]
+  props{}  (system neutral key-value)
+  traits[] (lightweight descriptors)
+  location_ref (stable_id or null)
+  owner_ref (stable_id or null)
+  visibility (player|gm|system)
+  provenance { package_id, source_path, file_hash }
+  status (active|deprecated|tombstoned)
+  created_event_id
+}
+```
+
+Edges:
+```
+Edge {
+  stable_id
+  type (contains|adjacent_to|member_of|bound_by_rule)
+  src_ref
+  dst_ref
+  validity { start_event_id, end_event_id? }
+  provenance { package_id, source_path, file_hash }
+}
+```
+
+Affordances vs Tags:
+- Tag: taxonomy / classification.
+- Affordance: capability exposure (gate enabling certain event_type predicates).
+Validation table binds (affordance, ruleset_version) → allowed_event_types[].
+
+---
+
+## 5. Determinism Layer
+
+### 5.1 Canonical Serialization Policy
+- UTF-8 NFC normalization.
+- Object keys sorted lexicographically (byte-wise).
+- Omit null fields.
+- Integers only (64-bit signed range). Large > 2^53-1 stored as strings in props if unavoidable (not in core mutation fields).
+- No floats permitted in event payload; fixed-point represented as integer minor units (e.g., *100).
+- Booleans lowercase JSON (`true`/`false`).
+- Arrays preserve order.
+- Canonical hash: SHA-256 over encoded canonical JSON bytes.
+
+### 5.2 Idempotency Key
+`idempotency_key = first_16_bytes( SHA256(plan_id || campaign_id || event_type || tool_name || ruleset_version || canonical(args_json)) )`
+Ensures network retries produce single ledger entry.
+
+### 5.3 RNG Stream Derivation
+Inputs:
+- campaign_rng_seed (128-bit raw)
+- stream_name (e.g., ability_check, loot, narration)
+- ruleset_version
+- tool_version
+- replay_ordinal (big-endian 8 bytes)
+Derivation:
+`base_seed = HKDF_SHA256( campaign_rng_seed, info = "AV1|" + ruleset_version + "|" + tool_version + "|" + stream + "|" + replay_ordinal_be8 )`
+Roll sequence:
+`roll_i = SHA256(base_seed || i_be4)` → map to dice size via modulus.
+Recorded in payload:
+```
+rng: {
+  stream: "ability_check",
+  base_seed_hex: "...",
+  rolls: ["d20:13","d20:5"],
+  inputs: { dc: 14, advantage: false }
+}
+```
+No ambient randomness outside Executor path (lint rule).
+
+---
+
+## 6. Concurrency & Consistency
+
+Optimistic Apply Contract:
+`apply_execution(request, expected_last_event_id)`  
+On mismatch: return conflict object
+```
+{
+  status: "conflict",
+  expected_last_event_id,
+  actual_last_event_id,
+  chain_tip_hash
+}
+```
+Clients may rebase (re-run plan) or abort.
+
+Dense ordering:
+- DB trigger asserts `NEW.replay_ordinal = (SELECT COALESCE(MAX(replay_ordinal),0)+1 FROM events WHERE campaign_id=NEW.campaign_id)`
+- Unique constraint enforces singularity.
+
+---
+
+## 7. Branching & Forking
+
+Fork:
+- Create new campaign row with reference `parent_snapshot_id`.
+- Replay snapshot + optionally additional seed transformations (none in MVP).
+- New replay_ordinal starts at 1 (fresh ledger context).
+No merge in MVP; ADR documents deliberate exclusion.
+
+Lineage:
+- Derived by walking parent_snapshot_id chain to root (package manifest).
+
+---
+
+## 8. Capability & Approval Model
+
+Tables:
+- roles (gm, player, system)
+- capabilities (event.*, tool.*)
+- role_capabilities
+- actor_role_assignments (discord_user_id, campaign_id, role_id)
+- capability_denies (optional future extension)
+
+Executor gate:
+1. Resolve actor effective capabilities.
+2. Validate required_capabilities from tool → event mapping.
+3. If event_type requires approval and approved_by null → reject (DB CHECK ensures enforcement).
+4. Record approved_by when GM or system grants.
+
+---
+
+## 9. Import Pipeline
+
+Phases (all transactional & idempotent):
+
+| Phase | Input | Output | Synthetic Events |
+|-------|-------|--------|------------------|
+| Manifest Validate | manifest + contracts | Parsed model | `seed.manifest.validated` (optional) |
+| Entities | entity files | Entities table rows | `seed.entity_created` |
+| Edges | edge files | Edge rows | `seed.edge_created` |
+| Tags/Affordances | ontology files | Tag & affordance registries | `seed.tag_registered` |
+| Lore Chunks | markdown | ContentChunk rows | `seed.content_chunk_ingested` |
+| Finalize | all above | ImportLog entries | `seed.import.complete` |
+
+Determinism:
+- Sorted deterministic iteration.
+- Collision policy: if stable_id exists with different file_hash → fail import.
+
+ImportLog Fields:
+`sequence_no, phase, object_type, stable_id, file_hash, action, timestamp, manifest_hash`
+
+---
+
+## 10. Retrieval / Knowledge Base
+
+ContentChunk:
+```
+chunk_id
+entity_ref (optional)
+title
+body_md
+audience (player|gm|system)
+tags[]
+affordances_hints[]
+source_path
+content_hash
+embedding_meta { model_id, index_strategy_id, built_at, source_hash }
+```
+Index provenance ensures stale detection when model or strategy changes. MVP: audience enforcement + simple tag filters; embeddings optional behind feature flag.
+
+---
+
+## 11. Planner & Orchestrator Integration
+
+- `/ask` (future ImprobabilityDrive) consumes retrieval index (audience-filtered) + entity name resolution (canonical stable_ids).
+- `/plan` emits Plan steps referencing stable_ids only (no fuzzy free text).
+- Orchestrator enforces policies (banned verbs, DC bounds, capabilities).
+- Executor produces an `ability_check_resolved` event (MVP) plus any narrative events (type `narration.emitted`).
+- Plan lineage: plan_id FK → each ExecutionRequest → events referencing execution_request_id.
+
+---
+
+## 12. Event Schema Versioning & Migration
+
+Registry:
+`event_type -> { latest_version, write_enabled, migrator_ref }`
+
+Replay:
+1. Load raw event (original version).
+2. If version < latest → apply pure migrator chain to current in-memory representation.
+3. Reduce to projections.
+4. Do not mutate stored payload (immutability).
+5. Record `migrator_applied_from` if migration occurred.
+
+Golden corpus fixtures ensure migrations remain reversible and idempotent.
+
+Reserved future event types:
+- `state_compacted`
+- `belief_projection_updated`
+- `package_dependency_upgraded`
+
+---
+
+## 13. Snapshot Lifecycle & Retention
+
+Cadence:
+- Every N=1000 events OR 24h OR manual trigger.
+Retention:
+- Keep last 5 full logical snapshots per branch initially (no pruning logic applied until compaction ADR executed).
+Validation:
+- `restore(snapshot) -> recompute state_digest` must match stored state_digest; CI gate.
+Signing (optional early, recommended):
+- ED25519 over canonical snapshot minus signature fields.
+- Key rotation: new key_id; historical signatures retained.
+
+---
+
+## 14. Observability & Metrics
+
+Counters:
+- `importer.entities.created`
+- `events.applied`
+- `events.conflict`
+- `replay.verify.ok/fail`
+- `snapshot.create.ok/fail`
+- `planner.tier.level.<n>`
+- `executor.apply.latency_ms` (histogram)
+- `rng.stream.<name>.rolls`
+
+Logs (structured):
+- plan_id, execution_request_id, event_id, replay_ordinal, chain_tip, state_digest
+- conflict detail on optimistic concurrency failure
+- hash_mismatch (critical alert)
+- import divergence (collision)
+
+Nightly Replay Verification Job:
+1. Select latest snapshot.
+2. Replay events to tip in isolated DB.
+3. Compare state_digest + chain tip.
+4. Emit `replay.verification` event or alert.
+
+---
+
+## 15. Performance & SLOs
+
+| Operation | SLO (P95) | Breach Trigger |
+|-----------|-----------|----------------|
+| Import small pack (≤200 entities) | ≤ 3s | 3 consecutive breaches |
+| Replay 2k events | ≤ 2s | Any > 2× SLO |
+| Snapshot creation | ≤ 500ms | 5 consecutive breaches |
+| Executor apply | ≤ 250ms | 5 consecutive breaches |
+
+Escalation: if replay SLO breached and event count > threshold (50k), evaluate physical snapshot enablement.
+
+---
+
+## 16. Security & Trust
+
+- Hash chain + snapshot signature for tamper evidence.
+- Package signature (publisher key) + optional registry notarization (future).
+- Capability enforcement at DB & application layers.
+- Audience gating prevents GM/system content leakage.
+- No secrets in events/snapshots (only `secret_ref` tokens).
+- Tool sandbox (resource-limited) recommended; base policy: no outbound network.
+
+---
+
+## 17. Backward & Forward Compatibility
+
+Backward:
+- Legacy tables (ContentNode) shimmed → ContentChunk adapter; dual read until migration window closure.
+- Events extended with nullable new columns initially; backfill stable_id & chain.
+
+Forward:
+- Reserved fields (phase_id, belief_state_ref).
+- Reserved event types (compaction, belief projection) documented to avoid name collisions.
+
+---
+
+## 18. MVP Scope (Adopt Now)
+
+Included:
+- Campaign Package (manifest + entities + chunks) minimal schema.
+- Deterministic importer + synthetic seed events.
+- Extended events table (envelope fields, hash chain, idempotency).
+- RNG derivation & recording.
+- Capability model + approval DB CHECK.
+- Logical snapshots + restore + state_digest.
+- Branch (fork) support (no merge).
+- Audience enforcement in retrieval.
+- CI canonical JSON test vectors + parity schema checks.
+
+Excluded (documented for future):
+- Merge / cherry-pick logic.
+- Physical snapshots.
+- Belief persistence.
+- Compaction meta-event logic.
+- Transparency log signing policy enforcement (initial stub only).
+- Prompt injection scrubbing.
+
+---
+
+## 19. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Canonical serialization drift | Golden test vectors; cross-platform CI |
+| Replay performance degradation | SLO monitoring + threshold switch to physical snapshots |
+| RNG misuse | Lint for disallowed randomness; unit tests assert stable sequences |
+| Capability misconfig | Startup health check verifying expected grants |
+| Hash chain corruption | On detection: halt applies; require admin intervention |
+| Import partial failure | Transactional phases; idempotent detection via stable_id + file_hash |
+| Event migration regressions | Golden corpus & migrator unit tests (pure functions) |
+
+---
+
+## 20. Acceptance Tests Matrix (MVP)
+
+| Test | Assertion |
+|------|-----------|
+| Genesis hash | Matches documented constant |
+| Idempotent retry storm | 1 event written; others return same event_id |
+| Conflict apply | Returns conflict payload; no partial ledger write |
+| Replay determinism | Restore -> state_digest stable |
+| Unicode normalization | Composed/decomposed produce identical content_hash |
+| Audience isolation | Player access to GM chunk denied |
+| RNG determinism | Same plan_id & ordinal => identical roll sequence |
+| Fork equivalence | Fork snapshot digest == baseline digest |
+| Hash chain continuity | Each prev_event_hash matches prior payload hash |
+
+---
+
+## 21. Implementation Ordering (Condensed)
+
+1. Canonical JSON encoder + test vectors.
+2. Alembic migrations (events, snapshots, campaigns, content_chunks, roles/capabilities).
+3. Genesis event emission on campaign creation.
+4. RNG utilities + HKDF helper.
+5. Importer (dry-run + apply) + synthetic seed events.
+6. Capability enforcement & approval DB checks.
+7. Executor: optimistic concurrency + idempotency key + roll capture.
+8. Snapshot create/restore + digest.
+9. Branch (fork) command.
+10. CI parity & replay verification job.
+
+---
+
+## 22. Glossary
+
+| Term | Definition |
+|------|------------|
+| Package | Immutable content bundle seeding a campaign |
+| Seed Event | Synthetic `seed.*` ledger entry produced during import |
+| Replay Ordinal | Dense per-campaign integer ordering events |
+| State Digest | Canonical hash summarizing derived world state |
+| Idempotency Key | Deterministic hash preventing duplicate event application |
+| Fork | New campaign branch initialized from snapshot |
+| Affordance | Tag enabling rules-governed action potential |
+| Capability | Permission to emit an event/tool action |
+
+---
+
+## 23. ADR Cross-References
+
+| ADR | Purpose |
+|-----|---------|
+| [ADR-0006](../adr/ADR-0006-event-envelope-and-hash-chain.md) | Deterministic Event Envelope & Hash Chain |
+| [ADR-0007](../adr/ADR-0007-canonical-json-numeric-policy.md) | Canonical JSON & Numeric Policy |
+| [ADR-0008](../adr/ADR-0008-rng-streams-seed-derivation.md) | RNG Streams & Seed Derivation |
+| [ADR-0009](../adr/ADR-0009-capability-approval-enforcement.md) | Capability & Approval Enforcement |
+| [ADR-0010](../adr/ADR-0010-snapshot-fork-lineage.md) | Snapshot & Fork Lineage |
+| [ADR-0011](../adr/ADR-0011-package-import-provenance.md) | Package Import Provenance |
+| [ADR-0012](../adr/ADR-0012-event-versioning-migration-protocol.md) | Event Versioning & Migration Protocol |
+
+---
+
+## 24. Open Questions (Deferred Explicitly)
+
+| Topic | Deferred Decision |
+|-------|-------------------|
+| Merge semantics | Out-of-scope MVP |
+| Belief state persistence | Post-MVP |
+| Physical snapshot format | Triggered by replay SLO breach |
+| Compaction process | After retention policy ADR |
+| Prompt injection mitigation | After initial retrieval hardening |
+
+---
+
+## 25. Conclusion
+
+This architecture establishes a deterministic, auditable substrate tightly aligned with action validation. It isolates volatility (content, planning sophistication) from invariants (ledger, canonical hashing, replay). It supplies measurable checkpoints (SLOs) and clear extension seams (forking, migrations, compaction) without overcommitting to premature complexity.

--- a/docs/implementation/epics/EPIC-ACTLOG-001-activitylog-mechanics-ledger.md
+++ b/docs/implementation/epics/EPIC-ACTLOG-001-activitylog-mechanics-ledger.md
@@ -1,3 +1,4 @@
+<!-- Renamed from activitylog-mechanics-ledger.md to EPIC-ACTLOG-001-activitylog-mechanics-ledger.md for consistency with EPIC-* naming. -->
 # EPIC-ACTLOG-001 — Mechanics ActivityLog Enablement
 
 **Objective.** Establish a structured, auditable ActivityLog for mechanics (dice rolls, checks, orchestrator-approved actions) with phased rollout, defensive guarantees, and minimal latency impact.
@@ -145,3 +146,4 @@ Event owners: Mechanics guild (primary) with Action Validation working group as 
 | Story 001H | (pending issue) | Staged rollout & latency. |
 
 Update with GitHub issue numbers upon creation.
+

--- a/docs/implementation/epics/EPIC-AVA-001-action-validation-architecture.md
+++ b/docs/implementation/epics/EPIC-AVA-001-action-validation-architecture.md
@@ -7,7 +7,7 @@
 **Key risks.** Schema drift between legacy and new contracts, insufficient telemetry to defend AI-assisted decisions, and rollout regressions when feature flags enable new behavior.
 
 **Linked assets.**
-- [ARCH-AVA-001 — Action Validation Architecture](../../architecture/action-validation-architecture.md)
+- [ARCH-AVA-001 — Action Validation Architecture](../../architecture/ARCH-AVA-001-action-validation-architecture.md)
 - [Implementation Plan — Action Validation Architecture](../action-validation-implementation.md)
 - [AIDD DoR/DoD Rituals](../dor-dod-guide.md)
 
@@ -144,7 +144,7 @@
 - **Summary.** Action Validation requires ActivityLog stories (ACTLOG 001A–001D minimum) to supply durable, queryable mechanics records (ExecutionRequest approvals, /roll, /check) and transcript linkage. Detailed milestones, tasks, and defenses live in EPIC-ACTLOG-001.
 - **Acceptance criteria (delegated).**
   - ActivityLog epic Stories 001A–001D completed (flag, schema, initial integrations, transcript linkage).
-    - Status tracked in [EPIC-ACTLOG-001](activitylog-mechanics-ledger.md) with DoR/DoD checklists marked complete.
+  - Status tracked in [EPIC-ACTLOG-001](EPIC-ACTLOG-001-activitylog-mechanics-ledger.md) with DoR/DoD checklists marked complete.
   - Feature flag `features.activity_log` remains a rollback lever; AVA tests pass with flag on/off (`tests/test_action_validation_activity_log_phase6.py::test_roll_command_activity_log_toggle`).
   - Cross-epic traceability updated when ActivityLog issue numbers created and validated via shared test coverage for orchestrator, `/check`, and `/roll` integrations (`tests/test_action_validation_activity_log_phase6.py`).
 - **Tasks (tracked in ACTLOG epic).** Former local tasks migrated and reissued with ACTLOG prefixes.

--- a/docs/implementation/epics/EPIC-CDA-CORE-001-deterministic-event-substrate.md
+++ b/docs/implementation/epics/EPIC-CDA-CORE-001-deterministic-event-substrate.md
@@ -1,0 +1,141 @@
+# EPIC-CDA-CORE-001 — Deterministic Event Substrate
+
+**Objective.** Establish the canonical, append-only event substrate (envelope, canonical JSON, hash chain, idempotency, replay ordinal guarantees) required for all downstream Campaign Data Architecture capabilities (importer, executor, snapshots, migrations).
+
+**Owner.** Campaign Data / Engine working group (persistence, executor, rules, observability, contracts).
+
+**Key risks.** Serialization drift across platforms, silent hash chain corruption, improper idempotency key collisions, and premature schema expansion without contract governance.
+
+**Linked assets.**
+- [ARCH-CDA-001 — Campaign Data & Deterministic World State Architecture](../../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+- [ADR-0006 — Event Envelope & Hash Chain](../../adr/ADR-0006-event-envelope-and-hash-chain.md)
+- [ADR-0007 — Canonical JSON & Numeric Policy](../../adr/ADR-0007-canonical-json-numeric-policy.md)
+- AIDD governance: [DoR/DoD Guide](../dor-dod-guide.md)
+
+**Definition of Ready.** Stories must additionally provide:
+- Enumerated envelope field list (final names, types, nullability) validated against ADR-0006.
+- Canonical JSON policy conformance checklist (key ordering, null omission, integer-only) referencing ADR-0007.
+- Test vector plan (golden inputs/outputs + negative cases for floats / key ordering / unicode normalization).
+- Idempotency key composition string frozen (exact concatenation order documented) with collision risk assessment.
+- Observability specification (metrics + structured log fields) for chain tip, replay ordinal, conflict, and idempotency reuse.
+
+**Definition of Done.**
+- Alembic migration(s) adding/altering `events` table with all envelope columns, constraints, and indexes merged.
+- Canonical encoder module + golden test vectors committed; cross-run determinism test passes (at least two platform seeds in CI matrix if available).
+- Hash chain continuity tests validate `prev_event_hash` correctness and genesis hash constant matches ADR-0006.
+- Idempotency key logic exposes helper producing stable 16-byte prefix; retry storm test shows single persisted event.
+- Structured logging emits chain tip hash, replay_ordinal, state placeholder (future digest), idempotency_key, and applies conflict outcome format.
+- Metrics registered: `events.applied`, `events.conflict`, `events.hash_mismatch`, `events.idempotent_reuse` (names documented in observability guide).
+- Lint / type / test quality gates green; no floats or NaN allowed anywhere in payload path (tests enforce rejection).
+- Documentation (architecture appendix or module docstring) explains encoder invariants and rollback strategy.
+
+---
+
+## Stories
+
+### STORY-CDA-CORE-001A — Event envelope migration & constraints ([#189](https://github.com/crashtestbrandt/Adventorator/issues/189))
+*Epic linkage:* Creates physical substrate (schema & DB invariants) enabling deterministic chain.
+
+- **Summary.** Introduce `events` table (or evolve existing) with full envelope columns, replay ordinal trigger/constraint, hash chain fields, idempotency uniqueness, and necessary indexes.
+- **Acceptance criteria.**
+  - Migration adds columns: `campaign_id`, `event_id` PK, `replay_ordinal` (gap-free trigger), `event_type`, `event_schema_version`, `world_time`, `wall_time_utc`, `prev_event_hash` (BINARY/bytea 32), `payload_hash` (BINARY/bytea 32), `idempotency_key` (BINARY/bytea 16), `actor_id`, `plan_id`, `execution_request_id`, `approved_by`, `payload` (JSONB), `migrator_applied_from` (nullable int), plus supporting FKs.
+  - Unique constraints: `(campaign_id, replay_ordinal)`, `(campaign_id, idempotency_key)`.
+  - Trigger enforces dense `replay_ordinal` per campaign.
+  - Genesis insertion test validates zeroed `prev_event_hash` and hash match with ADR constant.
+- **Tasks.**
+  - [ ] `TASK-CDA-CORE-MIG-01` — Author Alembic migration for envelope & constraints.
+  - [ ] `TASK-CDA-CORE-TRIG-02` — Implement replay ordinal trigger & test.
+  - [ ] `TASK-CDA-CORE-GEN-03` — Genesis event creation utility & test verifying hash.
+- **DoR.**
+  - Final column spec reviewed vs ADR-0006 field list.
+  - Hash algorithm (SHA-256) library choice confirmed.
+- **DoD.**
+  - Migration reversible; downgrade removes new columns and trigger.
+  - Tests cover duplicate idempotency key rejection.
+
+### STORY-CDA-CORE-001B — Canonical JSON encoder & golden vectors ([#190](https://github.com/crashtestbrandt/Adventorator/issues/190))
+*Epic linkage:* Ensures payload hashing & idempotency rely on stable serialization.
+
+- **Summary.** Implement canonical encoder enforcing ordering, null elision, UTF-8 NFC normalization, integer-only numeric policy; generate deterministic hash.
+- **Acceptance criteria.**
+  - Encoder outputs identical byte sequence for logically equivalent inputs across runs.
+  - Unicode composed/decomposed forms produce identical hashes (test with accented examples).
+  - Float presence triggers explicit ValueError with guidance.
+  - Golden vector fixtures (min 10) committed with precomputed hashes; CI test verifies no drift.
+- **Tasks.**
+  - [ ] `TASK-CDA-CORE-ENC-04` — Implement canonical encoder & hash helper.
+  - [ ] `TASK-CDA-CORE-VECT-05` — Add golden vector fixtures & test.
+  - [ ] `TASK-CDA-CORE-UNICODE-06` — Unicode normalization regression test.
+- **DoR.**
+  - Fixture schema & naming convention agreed.
+  - Negative case list enumerated (floats, NaN, key reordering, null retention attempts).
+- **DoD.**
+  - Encoder documented with invariants and rollback note.
+  - All golden vectors hashed & reviewed.
+
+### STORY-CDA-CORE-001C — Hash chain computation & verification ([#191](https://github.com/crashtestbrandt/Adventorator/issues/191))
+*Epic linkage:* Secures tamper-evident event history.
+
+- **Summary.** Integrate hash chain update logic in event creation path; supply verification routine and mismatch alert hook.
+- **Acceptance criteria.**
+  - On insert, `payload_hash = sha256(canonical_payload)`, `prev_event_hash` references prior event’s `payload_hash` (genesis zeroes).
+  - Verification routine traverses chain; mismatch test simulates corruption and raises defined exception / logs metric.
+  - Metric `events.hash_mismatch` increments on detection; structured log event includes offending ordinal & expected hash.
+- **Tasks.**
+  - [ ] `TASK-CDA-CORE-CHAIN-07` — Chain computation logic & insert integration.
+  - [ ] `TASK-CDA-CORE-VERIFY-08` — Verification routine & unit test with injected fault.
+  - [ ] `TASK-CDA-CORE-OBS-09` — Metric + structured log wiring for mismatches.
+- **DoR.**
+  - Chain mismatch severity classification defined (alert vs warn).
+- **DoD.**
+  - Fault injection test ensures detection path executed.
+  - Observability guide updated with mismatch handling.
+
+### STORY-CDA-CORE-001D — Idempotency key generation & collision tests ([#192](https://github.com/crashtestbrandt/Adventorator/issues/192))
+*Epic linkage:* Prevents duplicate event emission on network/client retries.
+
+- **Summary.** Provide helper constructing 16-byte key prefix per ADR composition spec; integrate into executor stub for early reuse; test retry storms.
+- **Acceptance criteria.**
+  - Deterministic composition: `SHA256(plan_id || campaign_id || event_type || tool_name || ruleset_version || canonical(args_json))[:16]`.
+  - Retry loop (≥10 simulated retries) produces one stored row; subsequent attempts return existing event metadata object.
+  - Collision fuzz test (random inputs N=10k) yields zero observed collisions (document expected probability).
+- **Tasks.**
+  - [ ] `TASK-CDA-CORE-IDEMP-10` — Idempotency helper implementation.
+  - [ ] `TASK-CDA-CORE-RETRY-11` — Retry storm test harness.
+  - [ ] `TASK-CDA-CORE-FUZZ-12` — Collision fuzz test & report.
+- **DoR.**
+  - Composition order finalized & documented.
+- **DoD.**
+  - Helper reused by executor prototype (story linkage).
+  - Fuzz test artifacts stored (log or markdown summary).
+
+### STORY-CDA-CORE-001E — Observability & metric taxonomy ([#193](https://github.com/crashtestbrandt/Adventorator/issues/193))
+*Epic linkage:* Supplies foundational telemetry for subsequent epics (executor, snapshots, importer).
+
+- **Summary.** Register counters/histograms, structured log fields; expose chain tip inspection API for verification jobs.
+- **Acceptance criteria.**
+  - Metrics present: `events.applied`, `events.conflict` (placeholder until executor), `events.idempotent_reuse`, `events.hash_mismatch`, latency histogram `event.apply.latency_ms` (stub timing instrumentation).
+  - Structured logs include: event_id, replay_ordinal, chain_tip_hash, idempotency_key_hex, plan_id (if provided), execution_request_id (if provided).
+  - Chain tip endpoint/function returns last (replay_ordinal, payload_hash).
+- **Tasks.**
+  - [ ] `TASK-CDA-CORE-METRIC-13` — Register metrics & document names.
+  - [ ] `TASK-CDA-CORE-LOG-14` — Add structured logging integration.
+  - [ ] `TASK-CDA-CORE-TIP-15` — Chain tip accessor & test.
+- **DoR.**
+  - Metric names vetted vs existing observability taxonomy.
+- **DoD.**
+  - Logging & metrics guides updated.
+  - Basic latency timing test recorded.
+
+---
+
+## Traceability Log
+
+| Artifact | Link | Notes |
+| --- | --- | --- |
+| Epic Issue | https://github.com/crashtestbrandt/Adventorator/issues/187 | EPIC-CDA-CORE-001 master issue. |
+| Architecture | ../../architecture/ARCH-CDA-001-campaign-data-architecture.md | Sections 3.2, 5, 6, 14 reference substrate. |
+| ADR-0006 | ../../adr/ADR-0006-event-envelope-and-hash-chain.md | Envelope fields & chain rules. |
+| ADR-0007 | ../../adr/ADR-0007-canonical-json-numeric-policy.md | Serialization invariants. |
+
+Update the table as GitHub issues are created to preserve AIDD traceability.

--- a/docs/implementation/epics/EPIC-CDA-IMPORT-002-package-import-and-provenance.md
+++ b/docs/implementation/epics/EPIC-CDA-IMPORT-002-package-import-and-provenance.md
@@ -1,0 +1,168 @@
+# EPIC-CDA-IMPORT-002 — Package Import & Provenance
+
+**Objective.** Implement deterministic, auditable campaign package import: manifest validation, ordered ingestion of entities/edges/ontology/content chunks, synthetic `seed.*` events emission, and provenance recording enabling full replay & lineage guarantees.
+
+**Owner.** Campaign Data / Content Pipeline working group (importer, persistence, ontology, retrieval, contracts).
+
+**Key risks.** Non-deterministic iteration leading to divergent replays, incomplete provenance (missing file hashes), collision handling ambiguity for `stable_id`, and drift between on-disk package artifacts and recorded ledger events.
+
+**Linked assets.**
+- [ARCH-CDA-001 — Campaign Data & Deterministic World State Architecture](../../architecture/ARCH-CDA-001-campaign-data-architecture.md)
+- [ADR-0011 — Package Import Provenance](../../adr/ADR-0011-package-import-provenance.md)
+- [ADR-0006 — Event Envelope & Hash Chain](../../adr/ADR-0006-event-envelope-and-hash-chain.md) (for synthetic seed events)
+- AIDD governance: [DoR/DoD Guide](../dor-dod-guide.md)
+
+**Definition of Ready.** Stories must additionally provide:
+- Manifest JSON schema (version, dependencies, content index, signatures) reviewed against ADR-0011.
+- Deterministic ordering specification (tuple sort key: `(kind, stable_id)` plus secondary path tie-breaker) documented.
+- Collision policy decisions enumerated (same `stable_id` + different `file_hash` ⇒ hard fail; identical hash ⇒ idempotent skip) with negative test plan.
+- List of synthetic event types to be emitted (`seed.manifest.validated`, `seed.entity_created`, `seed.edge_created`, `seed.tag_registered`, `seed.content_chunk_ingested`, `seed.import.complete`) with schema references or placeholders.
+- Provenance field mapping table (entity/edge/chunk → {package_id, source_path, file_hash}).
+- Rollback strategy (imports transactional per phase; re-run yields identical ledger segment or aborts cleanly).
+
+**Definition of Done.**
+- Importer module implements phased pipeline (manifest → entities → edges → ontology → lore → finalize) with transactional boundaries and idempotent re-entry.
+- Synthetic seed events emitted deterministically with stable replay_ordinal assignment and canonical payload hashing.
+- Provenance recorded: ImportLog table populated with sequence_no, phase, object_type, stable_id, file_hash, action, timestamp, manifest_hash.
+- Collision tests assert correct failure path & message content (includes conflicting stable_id and hash deltas).
+- Replay test: Fresh DB + imported package → derived `state_digest` stable across two consecutive imports (no duplicate ledger events beyond first attempt).
+- Structured logging includes per-phase counts and manifest hash; metrics registered: `importer.entities.created`, `importer.edges.created`, `importer.tags.registered`, `importer.chunks.ingested`, `importer.collision`, `importer.duration_ms` (histogram).
+- Feature flag (e.g., `features.importer`) governs activation; disabled path leaves legacy/manual seeding unmodified.
+- Quality gates green; golden manifest & sample content fixtures committed.
+- Documentation (developer guide or architecture appendix) explains phase ordering, failure semantics, and provenance guarantees.
+
+---
+
+## Stories
+
+### STORY-CDA-IMPORT-002A — Manifest validation & package_id registration
+*Epic linkage:* Establishes trusted seed manifest and genesis for subsequent phases.
+
+- **Summary.** Validate `package.manifest.json` (schema_version, engine_contract_range, content_index hashes, signatures) and record package row + synthetic `seed.manifest.validated` event.
+- **Acceptance criteria.**
+  - Manifest schema JSON in `contracts/package/` validated by existing script or extended checker.
+  - Invalid schema_version or missing file hash fails with descriptive error.
+  - Event payload includes canonical subset: `{package_id, manifest_hash, schema_version, ruleset_version}`.
+- **Tasks.**
+  - [ ] `TASK-CDA-IMPORT-MAN-01` — Manifest schema + validator.
+  - [ ] `TASK-CDA-IMPORT-HASH-02` — Manifest hashing + test.
+  - [ ] `TASK-CDA-IMPORT-SEED-03` — Emit `seed.manifest.validated` event.
+- **DoR.**
+  - Manifest fields list stabilized (ADR alignment).
+- **DoD.**
+  - Negative tests: missing field, tampered hash.
+
+### STORY-CDA-IMPORT-002B — Entity ingestion & synthetic events
+*Epic linkage:* Deterministically loads entity definitions with provenance & seed events.
+
+- **Summary.** Parse entity files, validate stable_id uniqueness, record provenance, emit `seed.entity_created` events in sorted order.
+- **Acceptance criteria.**
+  - Sort order deterministic; test demonstrates consistent event ordering across runs.
+  - Payload includes: `stable_id, kind, name, tags[], affordances[], provenance{package_id, source_path, file_hash}`.
+  - Collision (same stable_id different hash) aborts phase; identical hash skip counts toward idempotency metric.
+- **Tasks.**
+  - [ ] `TASK-CDA-IMPORT-ENT-04` — Entity parser & validation.
+  - [ ] `TASK-CDA-IMPORT-PROV-05` — Provenance capture & ImportLog entries.
+  - [ ] `TASK-CDA-IMPORT-SEED-06` — Emit entity seed events + ordering test.
+- **DoR.**
+  - Entity file schema agreed & documented.
+- **DoD.**
+  - Collision failure test implemented.
+
+### STORY-CDA-IMPORT-002C — Edge ingestion & temporal validity
+*Epic linkage:* Adds relational topology with validity metadata.
+
+- **Summary.** Ingest edge definitions (contains, adjacent_to, member_of, bound_by_rule) and emit `seed.edge_created` events.
+- **Acceptance criteria.**
+  - Validation ensures referenced entities exist (fail fast otherwise).
+  - Payload includes `stable_id, type, src_ref, dst_ref, provenance{...}`.
+  - ImportLog entries reflect edges with phase tagging.
+- **Tasks.**
+  - [ ] `TASK-CDA-IMPORT-EDGE-07` — Edge parser & referential validation.
+  - [ ] `TASK-CDA-IMPORT-SEED-08` — Emit edge seed events.
+  - [ ] `TASK-CDA-IMPORT-LOG-09` — ImportLog persistence test.
+- **DoR.**
+  - Edge file schema stable.
+- **DoD.**
+  - Referential failure test present.
+
+### STORY-CDA-IMPORT-002D — Ontology (tags & affordances) registration
+*Epic linkage:* Seeds controlled vocabulary before dependent features (retrieval, predicate gating).
+
+- **Summary.** Parse ontology files, register tags/affordances, emit `seed.tag_registered` events.
+- **Acceptance criteria.**
+  - Duplicate tag with same hash idempotent; differing definition fails import.
+  - Payload: `tag_id, category, version, provenance{...}`.
+  - Metrics: `importer.tags.registered` increments per unique registration.
+- **Tasks.**
+  - [ ] `TASK-CDA-IMPORT-ONTO-10` — Ontology parser & validation.
+  - [ ] `TASK-CDA-IMPORT-SEED-11` — Emit tag seed events.
+  - [ ] `TASK-CDA-IMPORT-METRIC-12` — Metrics & tests.
+- **DoR.**
+  - Ontology schema accepted.
+- **DoD.**
+  - Duplicate conflict test implemented.
+
+### STORY-CDA-IMPORT-002E — Lore content chunking & ingestion
+*Epic linkage:* Provides retrieval-ready modular content with provenance.
+
+- **Summary.** Chunk markdown lore with front-matter, register `ContentChunk` rows, emit `seed.content_chunk_ingested` events.
+- **Acceptance criteria.**
+  - Audience enforcement fields (`audience`) captured; optional embedding metadata gated behind flag.
+  - Payload includes `chunk_id, title, audience, tags[], source_path, content_hash`.
+  - Deterministic chunk ordering test ensures stable event sequence.
+- **Tasks.**
+  - [ ] `TASK-CDA-IMPORT-CHUNK-13` — Chunker implementation & hash.
+  - [ ] `TASK-CDA-IMPORT-SEED-14` — Emit content chunk seed events.
+  - [ ] `TASK-CDA-IMPORT-AUD-15` — Audience enforcement tests.
+- **DoR.**
+  - Front-matter schema frozen.
+- **DoD.**
+  - Unicode normalization test for content hashing.
+
+### STORY-CDA-IMPORT-002F — Finalization & ImportLog consolidation
+*Epic linkage:* Closes import transaction and asserts replay invariants.
+
+- **Summary.** Emit `seed.import.complete` event summarizing counts, finalize ImportLog, and run post-import replay sanity (fold to state_digest).
+- **Acceptance criteria.**
+  - Summary event payload: `{entity_count, edge_count, tag_count, chunk_count, manifest_hash}`.
+  - Post-import fold produces deterministic `state_digest`; stored for downstream snapshot reference.
+  - Metric `importer.duration_ms` recorded (start → finalize).
+- **Tasks.**
+  - [ ] `TASK-CDA-IMPORT-SUM-16` — Import completion event & counts.
+  - [ ] `TASK-CDA-IMPORT-FOLD-17` — Fold & state_digest verification test.
+  - [ ] `TASK-CDA-IMPORT-METRIC-18` — Duration metric + structured log.
+- **DoR.**
+  - Digest computation helper available (or stub planned in CORE epic).
+- **DoD.**
+  - Replay test passes; structured log shows counts.
+
+### STORY-CDA-IMPORT-002G — Idempotent re-run & rollback tests
+*Epic linkage:* Validates resilience and re-entrant design.
+
+- **Summary.** Ensure repeated import of the same package produces no additional seed events (or clearly deduplicated) and partial failures leave no inconsistent state.
+- **Acceptance criteria.**
+  - Second import run yields zero new entity/edge/tag/chunk seed events; ImportLog notes idempotent outcomes.
+  - Simulated failure mid-phase (entity collision) rolls back transaction; no partial events persisted.
+  - Metrics include `importer.idempotent` counter.
+- **Tasks.**
+  - [ ] `TASK-CDA-IMPORT-RERUN-19` — Re-run test & assertion.
+  - [ ] `TASK-CDA-IMPORT-FAIL-20` — Failure injection harness.
+  - [ ] `TASK-CDA-IMPORT-METRIC-21` — Idempotent metric registration.
+- **DoR.**
+  - Failure cases enumerated (collision, missing dependency file, invalid YAML/JSON).
+- **DoD.**
+  - Harness logs scenario & outcome.
+
+---
+
+## Traceability Log
+
+| Artifact | Link | Notes |
+| --- | --- | --- |
+| Epic Issue | https://github.com/crashtestbrandt/Adventorator/issues/188 | EPIC-CDA-IMPORT-002 master issue. |
+| Architecture | ../../architecture/ARCH-CDA-001-campaign-data-architecture.md | Sections 3.1, 3.2, 9 reference importer & seed events. |
+| ADR-0011 | ../../adr/ADR-0011-package-import-provenance.md | Provenance + ImportLog model. |
+| ADR-0006 | ../../adr/ADR-0006-event-envelope-and-hash-chain.md | Event emission & payload hashing for seed events. |
+
+Update the table as GitHub issues are created to preserve AIDD traceability.

--- a/docs/implementation/epics/EPIC-IPD-001-improbability-drive.md
+++ b/docs/implementation/epics/EPIC-IPD-001-improbability-drive.md
@@ -7,7 +7,7 @@
 **Key risks.** Tag ontology drift, inadequate disambiguation leading to unsafe or confusing plans, privacy/PII exposure in logs, and rollout regressions when enabling /ask and tagging.
 
 **Linked assets.**
-- [ARCH-AVA-001 — Action Validation Architecture](../../architecture/action-validation-architecture.md)
+- [ARCH-AVA-001 — Action Validation Architecture](../../architecture/ARCH-AVA-001-action-validation-architecture.md)
 - [Implementation Plan — ImprobabilityDrive](../improbability-drive-implementation.md)
 - [EPIC-AVA-001 — Action Validation Pipeline Enablement](./EPIC-AVA-001-action-validation-architecture.md)
 - AIDD governance: [DoR/DoD](../dor-dod-guide.md)
@@ -233,7 +233,7 @@ Module placement:
 | Artifact | Link | Notes |
 | --- | --- | --- |
 | Epic Issue | [TBD](https://github.com/crashtestbrandt/Adventorator/issues/) | Create and link the GitHub issue number when opened. |
-| Architecture | ../../architecture/action-validation-architecture.md | Component 1 (ImprobabilityDrive) specification. |
+| Architecture | ../../architecture/ARCH-AVA-001-action-validation-architecture.md | Component 1 (ImprobabilityDrive) specification. |
 | Implementation Plan | ../improbability-drive-implementation.md | Phases, validation, and rollout plan. |
 
 Update the table as GitHub issues are created to preserve AIDD traceability.

--- a/docs/implementation/epics/README.md
+++ b/docs/implementation/epics/README.md
@@ -12,7 +12,7 @@ Use the GitHub issue templates located in [`.github/ISSUE_TEMPLATE/`](../../.git
 | Epic | Objective | Primary Systems | Reference Assets |
 | --- | --- | --- | --- |
 | [EPIC-CORE-001](./core-ai-systems.md) | Harden the core planner → orchestrator → executor loop for hybrid AI + deterministic play. | Planner, Orchestrator, Executor, Action Validation | [ADR-0001](../../adr/ADR-0001-planner-routing.md), [ADR-0002](../../adr/ADR-0002-orchestrator-defenses.md), [ADR-0003](../../adr/ADR-0003-executor-preview-apply.md), [Core Systems C4](../../architecture/core-systems-context.md) |
-| [EPIC-AVA-001](./action-validation-architecture.md) | Roll out the Action Validation pipeline with deterministic guardrails and feature-flagged stages. | Planner, Orchestrator, Executor, MCP | [ARCH-AVA-001](../../architecture/action-validation-architecture.md), [Implementation Plan](../action-validation-implementation.md) |
+| [EPIC-AVA-001](./EPIC-AVA-001-action-validation-architecture.md) | Roll out the Action Validation pipeline with deterministic guardrails and feature-flagged stages. | Planner, Orchestrator, Executor, MCP | [ARCH-AVA-001](../../architecture/ARCH-AVA-001-action-validation-architecture.md), [Implementation Plan](../action-validation-implementation.md) |
 | [EPIC-ENC-002](./encounter-turn-engine.md) | Deliver a feature-flagged encounter and turn engine that is observable, testable, and safe for live campaigns. | Encounter mechanics, Executor, Events Ledger | [ADR-0003](../../adr/ADR-0003-executor-preview-apply.md), [Encounter Observability Guide](../observability-and-flags.md) |
 
 When a new initiative emerges, add a markdown file here with the same structure, then create the associated GitHub issues.

--- a/docs/implementation/improbability-drive-implementation.md
+++ b/docs/implementation/improbability-drive-implementation.md
@@ -159,6 +159,6 @@ Smoke test with Web CLI or Discord stub once `/ask` exists. Validate counters vi
 
 ## References
 
-- Architecture: /docs/architecture/action-validation-architecture.md
+- Architecture: /docs/architecture/ARCH-AVA-001-action-validation-architecture.md
 - AVA Epic: /docs/implementation/epics/EPIC-AVA-001-action-validation-architecture.md
 - AIDD Governance: /docs/implementation/dor-dod-guide.md

--- a/docs/smoke/validation-runbook-story-ava-001i-tiered-planning.md
+++ b/docs/smoke/validation-runbook-story-ava-001i-tiered-planning.md
@@ -226,7 +226,7 @@ If all boxes checked, manual validation for STORY-AVA-001I passes.
 
 ---
 ## 11. Updating Epic Task Status
-After validation, update `STORY-AVA-001I` tasks in `docs/implementation/epics/action-validation-architecture.md` from `[ ]` to `[x]` for:
+After validation, update `STORY-AVA-001I` tasks in `docs/implementation/epics/EPIC-AVA-001-action-validation-architecture.md` from `[ ]` to `[x]` for:
 - `TASK-AVA-TIER-26`
 - `TASK-AVA-GUARD-27`
 - `TASK-AVA-TEST-28`


### PR DESCRIPTION
## Summary
Introduce Campaign Data Architecture documentation (ARCH-CDA-001) and align roadmap + cross-cutting epics with deterministic event substrate (EPIC-CDA-CORE-001) and package import & provenance (EPIC-CDA-IMPORT-002). Renamed Action Validation architecture doc to ARCH-AVA-001 for naming consistency and added ActivityLog epic stub (EPIC-ACTLOG-001). Updated roadmap sections 5,7,9 to replace generic ingestion wording with deterministic package import phases and substrate priorities.

## Related Work
- **Feature Epic(s):** #187 (CORE substrate), #188 (IMPORT), EPIC-ACTLOG-001 (planned), EPIC-AVA-001 (dependency alignment)
- **Story(ies):** #189 #190 #191 #192 #193 (substrate stories referenced in CORE epic)
- **Task(s):** (Tasks enumerated inside epics; no new task issue numbers created in this PR)
- **ADR(s):** [ADR-0004](docs/adr/ADR-0004-mcp-adapter-architecture.md), [ADR-0006](docs/adr/ADR-0006-event-envelope-and-hash-chain.md), [ADR-0007](docs/adr/ADR-0007-canonical-json-numeric-policy.md), [ADR-0011](docs/adr/ADR-0011-package-import-provenance.md)

## Architecture Impact
- [ ] No architectural changes
- [x] Yes, ADR(s) linked above

**Contracts/Interfaces Changed:** None in code; documentation adds canonical data contract descriptions (no runtime impact).
**Persistence/Infra Changes:** None yet—migrations for substrate/importer not included in this PR.
**New Dependencies:** None.

## Tests & Quality Gates
- [ ] Unit tests added/updated (docs-only change)
- [ ] Property/contract tests added/updated
- [ ] Integration tests added/updated
- [ ] AI evals run (N/A for docs)
- [ ] Coverage ≥ target (unchanged)
- [ ] Mutation score ≥ target (unchanged)

(Documentation only: skipping code quality gate updates per AGENTS.md guidance for docs-only edits.)

## Observability & Ops
- [ ] Metrics/logs/traces updated (future PRs will implement substrate & importer metrics)
- [ ] Alerts/dashboards updated
- [ ] Runbooks updated (one validation runbook link path adjusted to new naming)

## Checklist
- [x] Code follows style guidelines (N/A: docs only; formatting consistent)
- [x] Docs updated (architecture, roadmap, epics)
- [x] Feature behind a flag (Referenced: features.activity_log, features.importer (planned), features.events already exist)
- [x] Rollback plan documented (Revert rename commit to restore previous doc names; roadmap modifications are non-breaking)

