### PR TITLE
Implement deterministic event envelope schema

### DIFF
--- a/migrations/versions/b7c8d9e0f1a2_story_cda_core_001a_events_envelope.py
+++ b/migrations/versions/b7c8d9e0f1a2_story_cda_core_001a_events_envelope.py
@@ -1,0 +1,162 @@
+"""Story CDA CORE 001A events envelope and trigger"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_EVENTS_REPLAY_TRIGGER_FN = "events_enforce_dense_replay_fn"
+_EVENTS_REPLAY_TRIGGER = "events_enforce_dense_replay"
+
+_POSTGRES_REPLAY_FN_SQL = f"""
+CREATE OR REPLACE FUNCTION {_EVENTS_REPLAY_TRIGGER_FN}()
+RETURNS TRIGGER AS $$
+DECLARE
+    last_ordinal integer;
+BEGIN
+    SELECT replay_ordinal INTO last_ordinal
+    FROM events
+    WHERE campaign_id = NEW.campaign_id
+    ORDER BY replay_ordinal DESC
+    LIMIT 1
+    FOR UPDATE;
+
+    IF last_ordinal IS NULL THEN
+        IF NEW.replay_ordinal IS NULL THEN
+            NEW.replay_ordinal := 0;
+        ELSIF NEW.replay_ordinal <> 0 THEN
+            RAISE EXCEPTION USING MESSAGE = format(
+                'Replay ordinal must start at 0 for campaign %%s (got %%s)',
+                NEW.campaign_id,
+                NEW.replay_ordinal
+            );
+        END IF;
+    ELSE
+        IF NEW.replay_ordinal IS NULL THEN
+            NEW.replay_ordinal := last_ordinal + 1;
+        ELSIF NEW.replay_ordinal <> last_ordinal + 1 THEN
+            RAISE EXCEPTION USING MESSAGE = format(
+                'Replay ordinal must increment by 1 for campaign %%s (expected %%s got %%s)',
+                NEW.campaign_id,
+                last_ordinal + 1,
+                NEW.replay_ordinal
+            );
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_POSTGRES_REPLAY_TRIGGER_SQL = f"""
+CREATE TRIGGER {_EVENTS_REPLAY_TRIGGER}
+BEFORE INSERT ON events
+FOR EACH ROW
+EXECUTE FUNCTION {_EVENTS_REPLAY_TRIGGER_FN}();
+"""
+
+_SQLITE_REPLAY_TRIGGER_SQL = f"""
+CREATE TRIGGER {_EVENTS_REPLAY_TRIGGER}
+BEFORE INSERT ON events
+BEGIN
+    SELECT
+        CASE
+            WHEN NEW.replay_ordinal IS NULL THEN
+                RAISE(ABORT, 'replay_ordinal must not be NULL')
+            WHEN NEW.replay_ordinal <> (
+                COALESCE(
+                    (SELECT replay_ordinal FROM events WHERE campaign_id = NEW.campaign_id ORDER BY replay_ordinal DESC LIMIT 1),
+                    -1
+                ) + 1
+            ) THEN
+                RAISE(ABORT, 'replay_ordinal must form a dense sequence per campaign')
+        END;
+END;
+"""
+
+
+def _create_trigger() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(sa.text(_POSTGRES_REPLAY_FN_SQL))
+        op.execute(sa.text(_POSTGRES_REPLAY_TRIGGER_SQL))
+    elif dialect == "sqlite":
+        op.execute(sa.text(_SQLITE_REPLAY_TRIGGER_SQL))
+
+
+def _drop_trigger() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(sa.text(f"DROP TRIGGER IF EXISTS {_EVENTS_REPLAY_TRIGGER} ON events"))
+        op.execute(sa.text(f"DROP FUNCTION IF EXISTS {_EVENTS_REPLAY_TRIGGER_FN}()"))
+    elif dialect == "sqlite":
+        op.execute(sa.text(f"DROP TRIGGER IF EXISTS {_EVENTS_REPLAY_TRIGGER}"))
+
+
+def upgrade() -> None:
+    # Replace legacy events table with deterministic envelope columns
+    op.drop_table("events")
+    op.create_table(
+        "events",
+        sa.Column("event_id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column("campaign_id", sa.Integer(), sa.ForeignKey("campaigns.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("scene_id", sa.Integer(), sa.ForeignKey("scenes.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("replay_ordinal", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("event_schema_version", sa.Integer(), nullable=False),
+        sa.Column("world_time", sa.BigInteger(), nullable=False),
+        sa.Column("wall_time_utc", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("prev_event_hash", sa.LargeBinary(length=32), nullable=False),
+        sa.Column("payload_hash", sa.LargeBinary(length=32), nullable=False),
+        sa.Column("idempotency_key", sa.LargeBinary(length=16), nullable=False),
+        sa.Column("actor_id", sa.String(length=64), nullable=True),
+        sa.Column("plan_id", sa.String(length=64), nullable=True),
+        sa.Column("execution_request_id", sa.String(length=64), nullable=True),
+        sa.Column("approved_by", sa.String(length=64), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("migrator_applied_from", sa.Integer(), nullable=True),
+        sa.UniqueConstraint("campaign_id", "replay_ordinal", name="ux_events_campaign_replay"),
+        sa.UniqueConstraint("campaign_id", "idempotency_key", name="ux_events_campaign_idempotency"),
+    )
+    op.create_index("ix_events_campaign_replay", "events", ["campaign_id", "replay_ordinal"])
+    op.create_index("ix_events_campaign_wall_time", "events", ["campaign_id", "wall_time_utc"])
+    op.create_index("ix_events_campaign_actor", "events", ["campaign_id", "actor_id"])
+    op.create_index("ix_events_plan", "events", ["plan_id"])
+    op.create_index("ix_events_execution_request", "events", ["execution_request_id"])
+    _create_trigger()
+
+
+def downgrade() -> None:
+    _drop_trigger()
+    op.drop_index("ix_events_execution_request", table_name="events")
+    op.drop_index("ix_events_plan", table_name="events")
+    op.drop_index("ix_events_campaign_actor", table_name="events")
+    op.drop_index("ix_events_campaign_wall_time", table_name="events")
+    op.drop_index("ix_events_campaign_replay", table_name="events")
+    op.drop_table("events")
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True, nullable=False),
+        sa.Column("scene_id", sa.Integer(), sa.ForeignKey("scenes.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("actor_id", sa.String(length=64), nullable=True),
+        sa.Column("type", sa.String(length=64), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("request_id", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+    )
+    op.create_index("ix_events_scene_time", "events", ["scene_id", "created_at"])
+    op.create_index("ix_events_scene_actor_time", "events", ["scene_id", "actor_id", "created_at"])
+    op.create_index(op.f("ix_events_type"), "events", ["type"])
+    op.create_index(op.f("ix_events_request_id"), "events", ["request_id"])

--- a/src/Adventorator/events/__init__.py
+++ b/src/Adventorator/events/__init__.py
@@ -1,0 +1,23 @@
+"""Event ledger helpers."""  # noqa: N999
+
+from .ledger import (
+    GENESIS_EVENT_TYPE,
+    GENESIS_PAYLOAD_HASH,
+    GENESIS_PREVIOUS_HASH,
+    compute_idempotency_key,
+    compute_payload_hash,
+    create_genesis_event,
+    ensure_genesis_event,
+    get_chain_tip,
+)
+
+__all__ = [
+    "GENESIS_EVENT_TYPE",
+    "GENESIS_PAYLOAD_HASH",
+    "GENESIS_PREVIOUS_HASH",
+    "compute_idempotency_key",
+    "compute_payload_hash",
+    "create_genesis_event",
+    "ensure_genesis_event",
+    "get_chain_tip",
+]

--- a/src/Adventorator/events/ledger.py
+++ b/src/Adventorator/events/ledger.py
@@ -1,0 +1,141 @@
+"""Utilities for the deterministic event ledger."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from Adventorator import models
+
+GENESIS_EVENT_TYPE = "campaign.genesis"
+GENESIS_PREVIOUS_HASH = b"\x00" * 32
+
+
+def _canonical_payload_bytes(payload: Mapping[str, Any] | None) -> bytes:
+    """Serialize payload deterministically for hashing."""
+
+    if payload is None:
+        payload = {}
+    try:
+        serialized = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    except TypeError as exc:  # pragma: no cover - defensive; tests cover happy path
+        raise ValueError("Payload must be JSON-serializable") from exc
+    return serialized.encode("utf-8")
+
+
+def compute_payload_hash(payload: Mapping[str, Any] | None) -> bytes:
+    """Compute SHA-256 over the canonical payload representation."""
+
+    return hashlib.sha256(_canonical_payload_bytes(payload)).digest()
+
+
+GENESIS_PAYLOAD_HASH = compute_payload_hash({})
+
+
+def compute_idempotency_key(
+    *,
+    campaign_id: int,
+    event_type: str,
+    payload: Mapping[str, Any] | None,
+    plan_id: str | None = None,
+    execution_request_id: str | None = None,
+) -> bytes:
+    """Return a stable 16-byte idempotency key prefix."""
+
+    h = hashlib.sha256()
+    h.update(str(campaign_id).encode())
+    h.update(b"\x1f")
+    h.update(event_type.encode())
+    h.update(b"\x1f")
+    if plan_id:
+        h.update(plan_id.encode())
+    h.update(b"\x1f")
+    if execution_request_id:
+        h.update(execution_request_id.encode())
+    h.update(b"\x1f")
+    h.update(_canonical_payload_bytes(payload))
+    return h.digest()[:16]
+
+
+def _genesis_idempotency_key(campaign_id: int) -> bytes:
+    h = hashlib.sha256()
+    h.update(f"genesis:{campaign_id}".encode())
+    return h.digest()[:16]
+
+
+async def get_chain_tip(session: AsyncSession, *, campaign_id: int) -> tuple[int, bytes] | None:
+    """Return the latest replay ordinal and payload hash for a campaign."""
+
+    q = await session.execute(
+        select(models.Event.replay_ordinal, models.Event.payload_hash)
+        .where(models.Event.campaign_id == campaign_id)
+        .order_by(models.Event.replay_ordinal.desc())
+        .limit(1)
+    )
+    row = q.first()
+    if row is None:
+        return None
+    return int(row.replay_ordinal), bytes(row.payload_hash)
+
+
+async def create_genesis_event(
+    session: AsyncSession,
+    *,
+    campaign_id: int,
+    wall_time_utc: datetime | None = None,
+) -> models.Event:
+    """Insert the genesis event for a campaign; caller ensures none exists."""
+
+    wall_time = wall_time_utc or datetime.now(timezone.utc)
+    event = models.Event(
+        campaign_id=campaign_id,
+        scene_id=None,
+        replay_ordinal=0,
+        event_type=GENESIS_EVENT_TYPE,
+        event_schema_version=1,
+        world_time=0,
+        wall_time_utc=wall_time,
+        prev_event_hash=GENESIS_PREVIOUS_HASH,
+        payload_hash=GENESIS_PAYLOAD_HASH,
+        idempotency_key=_genesis_idempotency_key(campaign_id),
+        actor_id=None,
+        plan_id=None,
+        execution_request_id=None,
+        approved_by=None,
+        payload={},
+        migrator_applied_from=None,
+    )
+    session.add(event)
+    await session.flush()
+    return event
+
+
+async def ensure_genesis_event(
+    session: AsyncSession,
+    *,
+    campaign_id: int,
+    wall_time_utc: datetime | None = None,
+) -> models.Event:
+    """Idempotently create the genesis event if missing."""
+
+    existing = await session.execute(
+        select(models.Event).where(
+            models.Event.campaign_id == campaign_id,
+            models.Event.replay_ordinal == 0,
+        )
+    )
+    event = existing.scalar_one_or_none()
+    if event is not None:
+        return event
+    return await create_genesis_event(session, campaign_id=campaign_id, wall_time_utc=wall_time_utc)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,16 @@
-import pytest
+from datetime import datetime, timezone
 
-from Adventorator import repos
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from Adventorator import models, repos
+from Adventorator.events import (
+    GENESIS_PAYLOAD_HASH,
+    GENESIS_PREVIOUS_HASH,
+    compute_idempotency_key,
+    compute_payload_hash,
+    ensure_genesis_event,
+)
 
 
 @pytest.mark.asyncio
@@ -28,9 +38,86 @@ async def test_append_and_list_events(db):
     )
 
     assert e1.id < e2.id
+    assert e1.replay_ordinal == 1
+    assert e2.replay_ordinal == 2
+    assert e2.prev_event_hash == e1.payload_hash
 
     events = await repos.list_events(db, scene_id=scene.id)
     assert [e.id for e in events] == [e1.id, e2.id]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_idempotency_key_rejected(db):
+    camp = await repos.get_or_create_campaign(db, 1, name="Dup Test")
+    scene = await repos.ensure_scene(db, camp.id, 200)
+
+    await repos.append_event(
+        db,
+        scene_id=scene.id,
+        actor_id="actor",
+        type="test",
+        payload={"foo": "bar"},
+        request_id="same",
+    )
+
+    with pytest.raises(IntegrityError):
+        await repos.append_event(
+            db,
+            scene_id=scene.id,
+            actor_id="actor",
+            type="test",
+            payload={"foo": "bar"},
+            request_id="same",
+        )
+    await db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_replay_ordinal_trigger_enforces_dense(db):
+    camp = await repos.get_or_create_campaign(db, 1, name="Trigger")
+    scene = await repos.ensure_scene(db, camp.id, 300)
+    genesis = await ensure_genesis_event(db, campaign_id=camp.id)
+
+    rogue = models.Event(
+        campaign_id=camp.id,
+        scene_id=scene.id,
+        replay_ordinal=2,
+        event_type="test",
+        event_schema_version=1,
+        world_time=2,
+        wall_time_utc=datetime.now(timezone.utc),
+        prev_event_hash=bytes(genesis.payload_hash),
+        payload_hash=compute_payload_hash({"foo": 1}),
+        idempotency_key=compute_idempotency_key(
+            campaign_id=camp.id,
+            event_type="test",
+            payload={"foo": 1},
+            execution_request_id="rogue",
+        ),
+        actor_id=None,
+        plan_id=None,
+        execution_request_id="rogue",
+        approved_by=None,
+        payload={"foo": 1},
+        migrator_applied_from=None,
+    )
+    db.add(rogue)
+    with pytest.raises(IntegrityError):
+        await db.flush()
+    await db.rollback()
+
+
+@pytest.mark.asyncio
+async def test_genesis_event_has_expected_hash(db):
+    camp = await repos.get_or_create_campaign(db, 1, name="Genesis")
+
+    genesis = await ensure_genesis_event(db, campaign_id=camp.id)
+    assert genesis.replay_ordinal == 0
+    assert genesis.prev_event_hash == GENESIS_PREVIOUS_HASH
+    assert genesis.payload_hash == GENESIS_PAYLOAD_HASH
+
+    again = await ensure_genesis_event(db, campaign_id=camp.id)
+    assert genesis.event_id == again.event_id
 
 
 def test_fold_hp_view():


### PR DESCRIPTION
## Summary
- add Alembic migration introducing the deterministic `events` envelope schema plus dense replay ordinal triggers
- extend ORM models and repository helpers to populate hash chain, idempotency keys, and automatic genesis rows
- add ledger utilities and tests covering idempotency uniqueness, replay ordinal enforcement, and genesis hashes

## Related Work
- **Feature Epic(s):** #187
- **Story(ies):** #189
- **Task(s):** TASK-CDA-CORE-MIG-01, TASK-CDA-CORE-TRIG-02, TASK-CDA-CORE-GEN-03
- **ADR(s):** [ADR-0006](docs/adr/ADR-0006-event-envelope-and-hash-chain.md)

## Architecture Impact
- [ ] No architectural changes
- [x] Yes, ADR(s) linked above

If "Yes," summarize:
- **Contracts/Interfaces Changed:** Event ledger persistence contract gains deterministic envelope fields and trigger enforcement.
- **Persistence/Infra Changes:** Alembic migration replaces the `events` table, adds unique constraints, indexes, and replay ordinal triggers (Postgres + SQLite).
- **New Dependencies:** None.

## Tests & Quality Gates
- [x] Unit tests added/updated
- [ ] Property/contract tests added/updated
- [ ] Integration tests added/updated
- [ ] AI evals run (if applicable)
- [x] Coverage ≥ target
- [ ] Mutation score ≥ target

## Observability & Ops
- [ ] Metrics/logs/traces updated
- [ ] Alerts/dashboards updated
- [ ] Runbooks updated

## Checklist
- [x] Code follows style guidelines
- [ ] Docs updated (README, ADRs, etc.)
- [ ] Feature behind a flag
- [ ] Rollback plan documented


------
https://chatgpt.com/codex/tasks/task_e_68cf9df13ee8832388bd706ef2403421