### PR TITLE
194 story story ipd 001c nlu and tagging scaffold rule based baseline

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,6 +14,8 @@ predicate_gate = true
 mcp = false
 activity_log = true
 planning_tiers = true  # Enables tiered planning scaffolding (Level >1 expansion paths)
+improbability_drive = true
+ask = { enabled = true, nlu_rule_based = true, nlu_debug = true }
 
 # --- ImprobabilityDrive /ask feature flags ---
 # Two supported forms:

--- a/contracts/ontology/seed.json
+++ b/contracts/ontology/seed.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.1",
+  "actions": {
+    "attack": ["attack", "hit", "strike", "swing"],
+    "move": ["move", "go", "walk", "run"],
+    "cast": ["cast", "spell", "castspell"]
+  },
+  "targets": {
+    "goblin": { "type": "npc", "synonyms": ["goblin", "gobo"] },
+    "guard": { "type": "npc", "synonyms": ["guard", "watchman"] },
+    "door": { "type": "object", "synonyms": ["door", "gate"] }
+  },
+  "modifiers": ["carefully", "quickly", "silently", "stealthily"]
+}

--- a/docs/dev/ask-nlu-normalization.md
+++ b/docs/dev/ask-nlu-normalization.md
@@ -1,0 +1,22 @@
+# Rule-based Ask NLU: Normalization Rules (Seed)
+
+This document describes the initial deterministic rules used to parse `/ask` messages into an IntentFrame and AffordanceTags.
+
+- Tokenization: ASCII alpha tokens via regex `[A-Za-z]+`, lower-cased.
+- Stopwords: small closed set in code (`ask_nlu._STOPWORDS`).
+- Actions: matched by ontology synonyms -> normalized action key (e.g., hit/strike -> attack).
+- Targets: matched by ontology synonyms -> tag `target.<type>` with value namespace `npc:<id>` or `obj:<id>`.
+- Modifiers: matched from a small list of adverbs (e.g., quickly, silently).
+- Unknown tokens: surfaced as `unknown:<token>` tags.
+
+Locations:
+- Ontology seed: `contracts/ontology/seed.json`
+- Tests/fixtures: `tests/fixtures/ask/`
+
+Dev logging:
+- Enable `[features.ask].nlu_debug = true` in `config.toml` to emit structured debug logs (no new metrics).
+
+Limitations:
+- No pronoun/alias resolution.
+- No multi-word expressions.
+- No external NLP or network calls.

--- a/docs/implementation/stories/STORY-IPD-001C-nlu-tagging-baseline.md
+++ b/docs/implementation/stories/STORY-IPD-001C-nlu-tagging-baseline.md
@@ -1,36 +1,74 @@
 # STORY-IPD-001C — NLU and tagging scaffold (rule-based baseline)
 
-Epic: [EPIC-IPD-001 — ImprobabilityDrive Enablement](/docs/implementation/epics/EPIC-IPD-001-improbability-drive.md)
 Status: Planned
 Owner: NLU/Ontology WG
 
-## Summary
-Implement a deterministic, rule-based parser for action, actor, object/target refs, plus AffordanceTags extraction from a small ontology; include entity normalization hooks. This story owns the initial token/stopword heuristic; no external NLP.
+## Summary & Scope
+Implement a deterministic, rule-based parser for action, actor, and object/target references, plus AffordanceTags extraction from a small seed ontology; include entity normalization hooks. Own the initial token/stopword heuristic. No external NLP or network calls.
+
+- In scope:
+	- Deterministic, rule-based parser producing an IntentFrame (action, actor, object/target refs).
+	- AffordanceTags extractor with ontology lookups and normalization hooks.
+	- Tokenization and stopword heuristic; configurable via code/fixtures (no external models).
+	- Fixture-driven unit tests with golden outputs and paraphrase coverage.
+	- Optional structured debug logging behind a dev flag; documented limitations and examples.
+	- Feature-flag gating via `config.toml` under `[features]`.
+- Out of scope:
+	- External NLP libraries (e.g., spaCy, NLTK) or ML models; any network calls.
+	- Full knowledge-base adapter integration (beyond seed ontology lookup hooks).
+	- New metrics/dashboards or tracing; performance tuning beyond basic sanity checks.
+	- Security classification/PII detection; advanced normalization beyond seed rules.
+
+Epic Link: [EPIC-IPD-001 — ImprobabilityDrive Enablement](/docs/implementation/epics/EPIC-IPD-001-improbability-drive.md)
 
 ## Acceptance Criteria
-- Deterministic parsing with seeded examples; no network calls.
-- Tag extraction maps to ontology IDs; unrecognized tokens surfaced as `unknown:*` tags.
-- Unit tests cover varied phrasing and edge cases (empty/ambiguous).
-- Implementation avoids external NLP libraries (e.g., spaCy) per current decision; strictly rule-based and offline.
+Concrete, testable criteria (Gherkin welcome):
 
-## Tasks
-- [ ] TASK-IPD-NLU-07 — Rule-based parser for IntentFrame fields.
-- [ ] TASK-IPD-TAGS-08 — AffordanceTags extractor with ontology lookups.
-- [ ] TASK-IPD-TEST-09 — Fixture-driven tests with golden outputs.
-- [ ] TASK-IPD-DOC-10 — Document normalization rules and examples in docs/dev/.
+- [ ] Given a user utterance containing an action, actor, and target When parsed Then the same IntentFrame is produced deterministically across runs with no network calls.
+- [ ] Given tokens that map to ontology entries When tags are extracted Then tags include ontology IDs; unknown tokens surface as `unknown:*` tags.
+- [ ] Given empty or ambiguous input When parsed Then ambiguity is surfaced in structured fields and tests assert expected fallbacks.
+- [ ] Unit tests cover varied phrasing and edge cases using fixtures under `tests/fixtures/ask/`.
+- [ ] Implementation avoids external NLP libraries (e.g., spaCy); solution is strictly rule-based and offline.
+- [ ] Behavior is gated by `features.improbability_drive` and `features.ask_nlu_rule_based` (default true for the latter) in `config.toml`.
 
-## Definition of Ready
-- Ontology MVP defined; normalization rules agreed.
+## Contracts & Compatibility
+- OpenAPI/Protobuf/GraphQL deltas: None for this story (no new external API). Seed ontology lives under `contracts/ontology/` (v0.1 seed).
+- CDCs (consumer/provider): Internal consumer is the Ask/Interactions layer expecting an `IntentFrame` and `AffordanceTags`. Parser must be backward-compatible with unknown tokens via `unknown:*` sentinel tags.
+- Versioning & deprecation plan: Additive-only; unknown tokens tolerated. Behavior behind feature flags to allow safe rollout and rollback.
 
-## Definition of Done
-- Parser/extractor documented with examples and limitations.
-
-## Test Plan
-- Deterministic unit tests with paraphrases; ambiguity surfaced in structured fields.
-- Fixtures live under `tests/fixtures/ask/`; seed ontology under `contracts/ontology/`.
+## Test Strategy
+- Unit & fixture-based tests with golden outputs (including paraphrases and edge cases like empty/ambiguous).
+- Contract tests: validate shape of `IntentFrame` and `AffordanceTags` against contracts in `contracts/ask/` and ontology expectations in `contracts/ontology/`.
+- Integration slice: minimal flow through the Ask handler/responder with the rule-based parser enabled (no network, no external deps).
+- Performance: lightweight parsing; no explicit budget in this story, but include a sanity assertion that typical inputs parse within tens of milliseconds on dev hardware.
+- Security/abuse cases: input validation; ensure logs do not leak secrets; baseline repository scanners apply.
+- AI evals: N/A for this deterministic scaffold.
 
 ## Observability
-- Optional debug logs behind a dev flag; no new metrics required in this story.
+- Metrics: None added in this story (per current decision).
+- Logs: Optional structured debug logs with `error_code` for parse/ontology lookup failures; controlled by a dev flag.
+- Traces: Not introduced in this story.
+- Dashboards/alerts: No updates required.
+
+## Tasks
+- [ ] #IPD-NLU-Contracts — Define contract deltas (if any) and seed ontology details under `contracts/ontology/`.
+- [ ] TASK-IPD-TEST-09 — Write acceptance tests (fixture-driven with golden outputs).
+- [ ] TASK-IPD-NLU-07 / TASK-IPD-TAGS-08 — Implement parser and tag extractor against tests.
+- [ ] #IPD-NLU-Obs — Add optional debug logs (no new metrics/traces in this story).
+- [ ] TASK-IPD-DOC-10 — Update docs/runbook (normalization rules and examples in `docs/dev/`).
+
+## Definition of Ready (DoR)
+- [ ] Acceptance criteria defined
+- [ ] Contracts drafted and reviewed (ontology MVP defined; normalization rules agreed)
+- [ ] Test strategy approved
+- [ ] Observability plan documented
+
+## Definition of Done (DoD)
+- [ ] Acceptance criteria verified by automated tests
+- [ ] Contracts versioned & backward compatible (unknown tokens tolerated; CDC checks pass where applicable)
+- [ ] Observability signals implemented and documented (debug logging behind dev flag)
+- [ ] Security/SCA/SAST/secrets checks pass; basic perf sanity holds
+- [ ] Parser/extractor documented with examples and limitations; PR merged with all quality gates green
 
 ## Risks & Mitigations
 - Overfitting rules: keep coverage broad; add fixtures iteratively.

--- a/src/Adventorator/ask_nlu.py
+++ b/src/Adventorator/ask_nlu.py
@@ -1,0 +1,212 @@
+"""Rule-based NLU and affordance tagging scaffold (deterministic, offline).
+
+Implements:
+- Tokenization and stopword filtering
+- Ontology-backed action and target matching with simple synonym maps
+- Modifier capture
+- Unknown token surfacing via unknown:* tags
+
+No external libraries and no network calls by design.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+import structlog
+
+from Adventorator.schemas import AffordanceTag, IntentFrame
+
+_STOPWORDS: set[str] = {
+    "i",
+    "we",
+    "you",
+    "he",
+    "she",
+    "they",
+    "it",
+    "me",
+    "him",
+    "them",
+    "the",
+    "a",
+    "an",
+    "to",
+    "with",
+    "and",
+    "then",
+    "please",
+    "at",
+    "on",
+    "in",
+    "into",
+    "of",
+    "from",
+    "that",
+    "this",
+    "those",
+    "these",
+    "my",
+    "your",
+    "our",
+    "their",
+    "his",
+    "her",
+    "its",
+}
+
+
+@dataclass(frozen=True)
+class _Ontology:
+    actions: dict[str, list[str]]
+    targets: dict[str, dict]
+    modifiers: list[str]
+
+    @staticmethod
+    def load() -> _Ontology:
+        """Load the seed ontology from contracts/ontology/seed.json.
+
+        The file is intentionally small and offline. If not present, a minimal
+        built-in fallback is used so tests remain deterministic.
+        """
+        path = Path("contracts/ontology/seed.json")
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+        else:
+            data = {
+                "actions": {
+                    "attack": ["attack", "hit", "strike", "swing"],
+                    "move": ["move", "go", "walk", "run"],
+                    "cast": ["cast", "spell", "castspell"],
+                },
+                "targets": {
+                    "goblin": {"type": "npc", "synonyms": ["goblin", "gobo"]},
+                    "guard": {"type": "npc", "synonyms": ["guard", "watchman"]},
+                    "door": {"type": "object", "synonyms": ["door", "gate"]},
+                },
+                "modifiers": ["carefully", "quickly", "silently", "stealthily"],
+            }
+        actions = {k: [s.lower() for s in v] for k, v in (data.get("actions") or {}).items()}
+        targets = {
+            k: {
+                "type": (v or {}).get("type", "entity"),
+                "synonyms": [s.lower() for s in (v or {}).get("synonyms", [k])],
+            }
+            for k, v in (data.get("targets") or {}).items()
+        }
+        modifiers = [m.lower() for m in (data.get("modifiers") or [])]
+        return _Ontology(actions=actions, targets=targets, modifiers=modifiers)
+
+
+_ONTOLOGY = _Ontology.load()
+_log = structlog.get_logger()
+
+
+def _tokens(text: str) -> list[str]:
+    return [t.lower() for t in re.findall(r"[A-Za-z]+", text)]
+
+
+def _first_non_stop(tokens: Iterable[str]) -> str | None:
+    for t in tokens:
+        if t not in _STOPWORDS:
+            return t
+    return None
+
+
+def _match_action(tokens: list[str]) -> str:
+    # Prefer ontology synonyms → normalized action key
+    for t in tokens:
+        if t in _STOPWORDS:
+            continue
+        for action, syns in _ONTOLOGY.actions.items():
+            if t in syns:
+                return action
+    # Fallback to first non-stopword token or a safe default
+    return _first_non_stop(tokens) or "say"
+
+
+def _match_actions(tokens: list[str]) -> list[str]:
+    """Return all normalized actions found in token order (unique, stable)."""
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for t in tokens:
+        if t in _STOPWORDS:
+            continue
+        for action, syns in _ONTOLOGY.actions.items():
+            if t in syns and action not in seen:
+                seen.add(action)
+                ordered.append(action)
+    return ordered
+
+
+def _match_target(tokens: list[str]) -> tuple[str | None, AffordanceTag | None]:
+    for t in tokens:
+        if t in _STOPWORDS:
+            continue
+        for norm, meta in _ONTOLOGY.targets.items():
+            if t in meta.get("synonyms", [norm]):
+                t_type = str(meta.get("type", "entity"))
+                if t_type == "npc":
+                    key = "target.npc"
+                    value = f"npc:{norm}"
+                elif t_type == "object":
+                    key = "target.object"
+                    value = f"obj:{norm}"
+                else:
+                    key = "target.entity"
+                    value = f"ent:{norm}"
+                return norm, AffordanceTag(key=key, value=value, confidence=1.0)
+    return None, None
+
+
+def _collect_modifiers(tokens: list[str]) -> list[str]:
+    return [t for t in tokens if t in _ONTOLOGY.modifiers]
+
+
+def parse_and_tag(text: str, debug: bool = False) -> tuple[IntentFrame, list[AffordanceTag]]:
+    """Parse user text into an IntentFrame and AffordanceTags.
+
+    Deterministic and offline: relies only on local ontology and simple rules.
+    """
+    toks = _tokens(text)
+    actions = _match_actions(toks)
+    action = actions[0] if actions else _match_action(toks)
+    target_ref, target_tag = _match_target(toks)
+    modifiers = _collect_modifiers(toks)
+
+    # Tag all recognized actions; first is the primary in the IntentFrame
+    action_set = actions or [action]
+    tags: list[AffordanceTag] = [
+        AffordanceTag(key=f"action.{a}") for a in dict.fromkeys(action_set)
+    ]
+    if target_tag:
+        tags.append(target_tag)
+
+    # Surface unknown tokens that aren't action/target/modifier/stopwords
+    known: set[str] = set(_STOPWORDS)
+    # Consider synonyms for all recognized actions as known (not unknown tokens)
+    for a in dict.fromkeys(action_set):
+        known.update(_ONTOLOGY.actions.get(a, []))
+    for meta in _ONTOLOGY.targets.values():
+        known.update(meta.get("synonyms", []))
+    known.update(_ONTOLOGY.modifiers)
+
+    for t in toks:
+        if t not in known:
+            tags.append(AffordanceTag(key=f"unknown.{t}"))
+
+    intent = IntentFrame(action=action, actor_ref=None, target_ref=target_ref, modifiers=modifiers)
+    if debug:
+        _log.debug(
+            "ask_nlu.debug",
+            tokens=toks,
+            action=action,
+            target_ref=target_ref,
+            modifiers=modifiers,
+            tags=[t.model_dump() for t in tags],
+        )
+    return intent, tags

--- a/src/Adventorator/config.py
+++ b/src/Adventorator/config.py
@@ -97,6 +97,8 @@ def _toml_settings_source() -> dict[str, Any]:
     out["features_ask_nlu_rule_based"] = bool(ask_cfg.get("nlu_rule_based", True))
     out["features_ask_kb_lookup"] = bool(ask_cfg.get("kb_lookup", False))
     out["features_ask_planner_handoff"] = bool(ask_cfg.get("planner_handoff", False))
+    # Dev toggle for verbose NLU logging (no metrics) — defaults off
+    out["features_ask_nlu_debug"] = bool(ask_cfg.get("nlu_debug", False))
 
     log_cfg = t.get("logging", {}) or {}
     # Derive per-handler levels if provided as strings; otherwise fallback from booleans
@@ -194,6 +196,7 @@ class Settings(BaseSettings):
     features_ask_nlu_rule_based: bool = True
     features_ask_kb_lookup: bool = False
     features_ask_planner_handoff: bool = False
+    features_ask_nlu_debug: bool = False
 
     # --- Retrieval (Phase 6) ---
     class RetrievalConfig(BaseModel):

--- a/tests/ask/test_ask_command_integration.py
+++ b/tests/ask/test_ask_command_integration.py
@@ -1,0 +1,22 @@
+import pytest
+
+from Adventorator.ask_nlu import parse_and_tag
+from Adventorator.commands.ask import _safe_echo
+from Adventorator.schemas import AskReport
+
+
+@pytest.mark.asyncio
+async def test_safe_echo_truncates():
+    s = _safe_echo("hello\nworld" * 20, limit=20)
+    assert len(s) <= 21 and s.endswith("…")
+
+
+def test_parse_round_trip():
+    text = "We swing at the guard silently"
+    intent, tags = parse_and_tag(text)
+    report = AskReport(raw_text=text, intent=intent, tags=tags)
+    s = report.to_json()
+    same = AskReport.from_json(s)
+    assert same.intent.action == "attack"
+    assert same.intent.target_ref == "guard"
+    assert "silently" in same.intent.modifiers

--- a/tests/ask/test_ask_flag_gating.py
+++ b/tests/ask/test_ask_flag_gating.py
@@ -1,0 +1,85 @@
+import pytest
+
+from Adventorator.command_loader import load_all_commands
+from Adventorator.commanding import Invocation, find_command
+
+
+class _SpyResponder:
+    def __init__(self):
+        self.messages: list[tuple[str, bool]] = []
+
+    async def send(self, content: str, *, ephemeral: bool = False):  # noqa: ANN001
+        self.messages.append((content, ephemeral))
+
+
+@pytest.mark.asyncio
+async def test_ask_disabled_shows_message():
+    load_all_commands()
+    cmd = find_command("ask", None)
+    assert cmd is not None
+
+    responder = _SpyResponder()
+    settings = type(
+        "S",
+        (),
+        {
+            "features_improbability_drive": False,
+            "features_ask": True,
+            "features_ask_nlu_rule_based": True,
+        },
+    )()
+
+    inv = Invocation(
+        name="ask",
+        subcommand=None,
+        options={"message": "attack goblin"},
+        user_id="u6",
+        channel_id="c6",
+        guild_id="g6",
+        responder=responder,
+        settings=settings,
+    )
+    opts = cmd.option_model.model_validate(inv.options)
+
+    await cmd.handler(inv, opts)
+
+    assert responder.messages
+    content, ephemeral = responder.messages[0]
+    assert ephemeral is True
+    assert "disabled" in content
+
+
+@pytest.mark.asyncio
+async def test_ask_rule_based_off_falls_back_to_minimal():
+    load_all_commands()
+    cmd = find_command("ask", None)
+    assert cmd is not None
+
+    responder = _SpyResponder()
+    settings = type(
+        "S",
+        (),
+        {
+            "features_improbability_drive": True,
+            "features_ask": True,
+            "features_ask_nlu_rule_based": False,
+        },
+    )()
+
+    inv = Invocation(
+        name="ask",
+        subcommand=None,
+        options={"message": "please attack the goblin"},
+        user_id="u7",
+        channel_id="c7",
+        guild_id="g7",
+        responder=responder,
+        settings=settings,
+    )
+    opts = cmd.option_model.model_validate(inv.options)
+
+    await cmd.handler(inv, opts)
+
+    assert responder.messages
+    content, _ = responder.messages[0]
+    assert "action='attack'" in content  # still infers the action via minimal fallback

--- a/tests/ask/test_fixture_golden_parsing.py
+++ b/tests/ask/test_fixture_golden_parsing.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+
+from Adventorator.ask_nlu import parse_and_tag
+
+
+def test_golden_basic_fixture():
+    p = Path("tests/fixtures/ask/golden_basic.json")
+    data = json.loads(p.read_text(encoding="utf-8"))
+
+    intent, tags = parse_and_tag(data["input"])  # type: ignore[index]
+
+    assert intent.action == data["intent"]["action"]
+    assert intent.target_ref == data["intent"]["target_ref"]
+    for m in data["intent"]["modifiers"]:
+        assert m in intent.modifiers
+
+    tag_keys = {(t.key, t.value) for t in tags}
+    for t in data["tags"]:
+        tup = (t.get("key"), t.get("value"))
+        assert tup in tag_keys
+
+
+def test_golden_ambiguous_fixture():
+    p = Path("tests/fixtures/ask/golden_ambiguous.json")
+    data = json.loads(p.read_text(encoding="utf-8"))
+
+    intent, tags = parse_and_tag(data["input"])  # type: ignore[index]
+    assert intent.action == data["intent"]["action"]
+    assert intent.target_ref == data["intent"]["target_ref"]
+    assert intent.modifiers == data["intent"]["modifiers"]
+    keys = {t.key for t in tags}
+    assert "action.attack" in keys
+
+
+def test_golden_sequence_fixture():
+    p = Path("tests/fixtures/ask/golden_sequence.json")
+    data = json.loads(p.read_text(encoding="utf-8"))
+
+    intent, tags = parse_and_tag(data["input"])  # type: ignore[index]
+    assert intent.action == data["intent"]["action"]
+    assert intent.target_ref == data["intent"]["target_ref"]
+    keys = {(t.key, t.value) for t in tags}
+    for t in data["tags"]:
+        tup = (t.get("key"), t.get("value"))
+        assert tup in keys

--- a/tests/ask/test_multi_action_tagging.py
+++ b/tests/ask/test_multi_action_tagging.py
@@ -1,0 +1,19 @@
+from Adventorator.ask_nlu import parse_and_tag
+
+
+def test_multi_action_tags_sequence_sentence():
+    text = "go to the door and attack"
+    intent, tags = parse_and_tag(text)
+
+    # Primary action remains the first recognized action
+    assert intent.action == "move"
+    assert intent.target_ref == "door"
+
+    keys = {t.key for t in tags}
+    assert "action.move" in keys
+    assert "action.attack" in keys, "secondary action should be surfaced via tags"
+
+    # Ensure door is recognized as the target object
+    target_tag = next((t for t in tags if t.key == "target.object"), None)
+    assert target_tag is not None
+    assert getattr(target_tag, "value", None) == "obj:door"

--- a/tests/ask/test_property_nlu.py
+++ b/tests/ask/test_property_nlu.py
@@ -1,0 +1,23 @@
+from hypothesis import given, strategies as st
+
+from Adventorator.ask_nlu import parse_and_tag
+from Adventorator.schemas import AskReport
+
+
+alpha_space = st.text(alphabet=st.characters(whitelist_categories=("Ll", "Lu")) | st.just(" "), min_size=0, max_size=40)
+
+
+@given(alpha_space)
+def test_parse_and_tag_deterministic_alpha_inputs(s: str):
+    # Ensure function is deterministic for simple alpha/space inputs
+    intent1, tags1 = parse_and_tag(s)
+    intent2, tags2 = parse_and_tag(s)
+
+    assert intent1 == intent2
+    assert [t.model_dump() for t in tags1] == [t.model_dump() for t in tags2]
+
+    # Ensure AskReport round-trip is stable
+    r1 = AskReport(raw_text=s, intent=intent1, tags=tags1)
+    same = AskReport.from_json(r1.to_json())
+    assert same.intent == intent1
+    assert [t.model_dump() for t in same.tags] == [t.model_dump() for t in tags1]

--- a/tests/ask/test_rule_based_nlu.py
+++ b/tests/ask/test_rule_based_nlu.py
@@ -1,0 +1,26 @@
+from Adventorator.ask_nlu import parse_and_tag
+
+
+def test_parse_and_tag_basic_attack():
+    text = "I attack the goblin quickly"
+    intent, tags = parse_and_tag(text)
+
+    assert intent.action == "attack"
+    assert intent.target_ref == "goblin"
+    assert "quickly" in intent.modifiers
+
+    keys = {t.key for t in tags}
+    assert "action.attack" in keys
+    assert any(t.key.startswith("target.") for t in tags)
+    # Unknown tokens should be minimal and not include known ones
+    assert not any(t.key == "unknown.attack" for t in tags)
+    assert not any(t.key == "unknown.goblin" for t in tags)
+
+
+def test_parse_and_tag_unknown_surfaces():
+    text = "bonk the frobnicator"
+    intent, tags = parse_and_tag(text)
+
+    # Without ontology match, action falls back to first non-stopword token
+    assert intent.action in {"bonk", "say"}
+    assert any(t.key.startswith("unknown.") for t in tags)

--- a/tests/fixtures/ask/golden_ambiguous.json
+++ b/tests/fixtures/ask/golden_ambiguous.json
@@ -1,0 +1,12 @@
+{
+  "input": "hit it",
+  "intent": {
+    "action": "attack",
+    "actor_ref": null,
+    "target_ref": null,
+    "modifiers": []
+  },
+  "tags": [
+    {"key": "action.attack", "confidence": 1.0}
+  ]
+}

--- a/tests/fixtures/ask/golden_basic.json
+++ b/tests/fixtures/ask/golden_basic.json
@@ -1,0 +1,13 @@
+{
+  "input": "I attack the goblin quickly",
+  "intent": {
+    "action": "attack",
+    "actor_ref": null,
+    "target_ref": "goblin",
+    "modifiers": ["quickly"]
+  },
+  "tags": [
+    {"key": "action.attack", "confidence": 1.0},
+    {"key": "target.npc", "value": "npc:goblin", "confidence": 1.0}
+  ]
+}

--- a/tests/fixtures/ask/golden_sequence.json
+++ b/tests/fixtures/ask/golden_sequence.json
@@ -1,0 +1,13 @@
+{
+  "input": "go to the door then attack",
+  "intent": {
+    "action": "move",
+    "actor_ref": null,
+    "target_ref": "door",
+    "modifiers": []
+  },
+  "tags": [
+    {"key": "action.move", "confidence": 1.0},
+    {"key": "target.object", "value": "obj:door", "confidence": 1.0}
+  ]
+}


### PR DESCRIPTION
## Summary
Deterministic, rule-based NLU and tagging scaffold for the `/ask` command.

Highlights:
- New offline parser (`src/Adventorator/ask_nlu.py`) that tokenizes input, filters stopwords, normalizes actions/targets against a seed ontology, captures modifiers, and surfaces unknown tokens as tags. No external NLP or network calls.
- Seed ontology (`contracts/ontology/seed.json`) defining actions, targets, and modifiers with synonyms.
- `/ask` handler uses rule-based NLU behind feature flags; appends a compact debug summary and emits an additional debug follow-up when the debug flag is enabled.
- Docs added for normalization rules and limitations; tests cover unit, integration, gating, and property-based determinism.

Behavior note (scope): We keep a single IntentFrame (one primary action) but now surface additional recognized actions via tags (e.g., `['move','attack']`) for sequence-like phrasing.

## Related Work
- **Feature Epic(s):** #178 
- **Story(ies):** #194 
- **Task(s):** N/A
- **ADR(s):** [ADR-0005](https://github.com/crashtestbrandt/Adventorator/docs/adr/ADR-0005-improbabilitydrive-contracts-and-flags.md)

## Architecture Impact
<!-- Does this PR introduce or modify architecture? -->
- [x] No architectural changes
- [ ] Yes, ADR(s) linked above

If "Yes," summarize:
- **Contracts/Interfaces Changed:** N/A
- **Persistence/Infra Changes:** N/A
- **New Dependencies:** None (uses stdlib + existing deps)

## Tests & Quality Gates
- [x] Unit tests added/updated
- [x] Property/contract tests added/updated
- [x] Integration tests added/updated
- [ ] AI evals run (if applicable)
- [x] Coverage ≥ target (ask suite and repo suite green; a few tests skipped by design)
- [ ] Mutation score ≥ target

## Observability & Ops
- [x] Metrics/logs/traces updated (structured debug log `ask_nlu.debug`; retains existing ask counters/histogram)
- [ ] Alerts/dashboards updated
- [ ] Runbooks updated

## Checklist
- [x] Code follows style guidelines (Ruff clean for changed files)
- [x] Docs updated (dev doc + story updated)
- [x] Feature behind a flag (`features.improbability_drive` and `features.ask.{nlu_rule_based,nlu_debug}`)
- [x] Rollback plan documented (disable flags to return to minimal action inference)

## Implementation Details

NLU and Tagging Implementation
- `src/Adventorator/ask_nlu.py`: deterministic parsing and tagging; multi-action tagging with the first recognized action as primary; target normalization to npc/object/entity; unknown token tags.
- `contracts/ontology/seed.json`: seed ontology of actions/targets/modifiers with synonyms.

Feature Flags and Configuration
- `config.toml`: added `[features]` table entry for `ask = { enabled = true, nlu_rule_based = true, nlu_debug = true }`.
- `src/Adventorator/config.py`: loads `features_ask_nlu_rule_based` and `features_ask_nlu_debug`.

Command Handler
- `src/Adventorator/commands/ask.py`: uses `parse_and_tag` when enabled; appends actions list to the summary and emits a compact “🔎 NLU debug” follow-up with tags when debug flag is on.

Docs
- `docs/dev/ask-nlu-normalization.md`: normalization rules, ontology, and debug usage notes.
- Story doc updated to template format and acceptance criteria.

Tests
- `tests/ask/test_rule_based_nlu.py`, `test_multi_action_tagging.py`, `test_fixture_golden_parsing.py`: unit + golden tests.
- `tests/ask/test_ask_flag_gating.py`, `test_ask_command_integration.py`, `test_contracts_round_trip.py`: gating/integration/contract round-trip.
- `tests/ask/test_property_nlu.py`: determinism/property test.

## How to run locally
```
# Start the app (if you use the web CLI)
# Ensure config flags are on: [features] improbability_drive=true; ask.enabled=true; ask.nlu_rule_based=true; ask.nlu_debug=true
# Then in shell:
web_cli.py ask "go to the door and attack"
```
