### PR TITLE
Remove Node.js setup from copilot workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,14 +35,6 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      # Node.js setup (for potential frontend tools)
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
-
       # Docker setup for service dependencies
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -98,8 +90,6 @@ jobs:
           if command -v uv >/dev/null 2>&1; then
             echo "uv version: $(uv --version)"
           fi
-          echo "Node.js version: $(node --version)"
-          echo "npm version: $(npm --version)"
           echo "Docker version: $(docker --version)"
           echo
           echo "=== Service Health Checks ==="


### PR DESCRIPTION
## Summary
- remove the Node.js setup step from the reusable Copilot workflow
- drop the Node.js/npm version checks from the environment verification output

## Related Work
- **Feature Epic(s):** N/A
- **Story(ies):** N/A
- **Task(s):** N/A
- **ADR(s):** N/A

## Architecture Impact
- [x] No architectural changes
- [ ] Yes, ADR(s) linked above

## Tests & Quality Gates
- [ ] Unit tests added/updated
- [ ] Property/contract tests added/updated
- [ ] Integration tests added/updated
- [ ] AI evals run (if applicable)
- [ ] Coverage ≥ target
- [ ] Mutation score ≥ target

## Observability & Ops
- [ ] Metrics/logs/traces updated
- [ ] Alerts/dashboards updated
- [ ] Runbooks updated

## Checklist
- [ ] Code follows style guidelines
- [x] Docs updated (README, ADRs, etc.)
- [ ] Feature behind a flag
- [ ] Rollback plan documented

------
https://chatgpt.com/codex/tasks/task_e_68d5c5800c048323bb3b4ffb1cd9f03a