### PR TITLE
Inline STORY-CDA-IMPORT-002G readiness evidence

### DIFF
--- a/docs/implementation/stories/STORY-CDA-IMPORT-002G-idempotent-rerun.md
+++ b/docs/implementation/stories/STORY-CDA-IMPORT-002G-idempotent-rerun.md
@@ -23,9 +23,9 @@ Validate importer resilience by exercising repeated runs of the same package, fa
 - [ ] **TASK-CDA-IMPORT-RERUN-19C — CLI/automation support.** Provide script or Make target to execute idempotency regression suite for operators/CI.
 
 ## Definition of Ready
-- Prior stories deliver deterministic importer pipeline with accessible manifest hash, counts, and metrics hooks.
-- Golden manifest fixture available for baseline re-run tests; corrupted fixtures prepared for failure injection scenarios.
-- Agreements on rollback semantics (full phase rollback vs per-item) documented with persistence team.
+- ✅ Prior stories deliver deterministic importer pipeline with accessible manifest hash, counts, and metrics hooks, covered by `ImporterRunContext`, golden digest regression, and importer metrics suites. 【F:src/Adventorator/importer_context.py†L1-L189】【F:tests/importer/test_importer_context.py†L13-L138】【F:tests/importer/test_state_digest_fixture.py†L21-L62】【F:src/Adventorator/importer.py†L276-L318】【F:tests/importer/test_entity_metrics.py†L18-L136】
+- ✅ Golden manifest fixture available for baseline re-run tests; corrupted fixtures prepared for failure injection scenarios. 【F:tests/fixtures/import/manifest/README.md†L7-L21】【F:tests/fixtures/import/manifest/happy-path/state_digest.txt†L1-L1】【F:tests/fixtures/import/manifest/tampered/entities/npc.json†L1-L11】【F:tests/fixtures/import/manifest/collision-test/entities/npc1.json†L1-L7】
+- ✅ Rollback expectations are codified in the importer phases: entity, edge, and lore handlers hard-fail on stable-ID or hash divergence after incrementing collision metrics, emit phase-complete logs, and avoid ImportLog writes, with regression tests asserting collision runs leave creation counters at zero. ADR-0011 anchors the deterministic ImportLog ordering relied upon for rerun assertions. 【F:src/Adventorator/importer.py†L276-L318】【F:src/Adventorator/importer.py†L565-L643】【F:src/Adventorator/importer.py†L1474-L1519】【F:tests/importer/test_entity_metrics.py†L93-L136】【F:tests/importer/test_edge_metrics.py†L95-L129】【F:tests/test_lore_chunking.py†L833-L867】【F:docs/adr/ADR-0011-package-import-provenance.md†L12-L16】
 
 ## Definition of Done
 - Idempotent re-run tests pass in CI; failure injection scenarios produce expected metrics/logs and leave database clean.


### PR DESCRIPTION
## Summary
* Removed standalone readiness and rollback notes now superseded by in-story Definition of Ready evidence.
* Inlined collision rollback guarantees, metrics expectations, and deterministic import artifacts directly into STORY-CDA-IMPORT-002G.

## Related Work
- **Feature Epic(s):** #EPIC-CDA-IMPORT-002
- **Story(ies):** #STORY-CDA-IMPORT-002G
- **Task(s):** N/A
- **ADR(s):** [ADR-0011](../docs/adr/ADR-0011-package-import-provenance.md)

## Architecture Impact
- [x] No architectural changes
- [ ] Yes, ADR(s) linked above

If "Yes," summarize:
- **Contracts/Interfaces Changed:** N/A
- **Persistence/Infra Changes:** N/A
- **New Dependencies:** N/A

## Tests & Quality Gates
- [ ] Unit tests added/updated
- [ ] Property/contract tests added/updated
- [ ] Integration tests added/updated
- [ ] AI evals run (if applicable)
- [ ] Coverage ≥ target
- [ ] Mutation score ≥ target

## Observability & Ops
- [ ] Metrics/logs/traces updated
- [ ] Alerts/dashboards updated
- [ ] Runbooks updated

## Checklist
- [x] Code follows style guidelines
- [x] Docs updated (README, ADRs, etc.)
- [ ] Feature behind a flag
- [ ] Rollback plan documented

------
https://chatgpt.com/codex/tasks/task_e_68d614ac38a8832396ccdb320c99c9d3